### PR TITLE
Meilleur formattage des fichiers Markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # Projet de loi pour une République numérique
 
-Le numérique et ses usages sont au cœur d’un vaste mouvement de transformation de notre économie, de redéfinition de nos espaces publics et privés, et de construction du lien social. Les conséquences de ces évolutions sont dès à présent globales, et dessinent l’avenir de l’ensemble de notre société. La République du 21e siècle sera nécessairement numérique : elle doit anticiper les changements à l’œuvre, en saisir pleinement les opportunités, et dessiner une société conforme à ses principes de liberté, d’égalité et de fraternité.
+Le numérique et ses usages sont au cœur d’un vaste mouvement de transformation de notre économie, de redéfinition de nos espaces publics et privés, et de construction du lien social. Les conséquences de ces évolutions sont dès à présent globales, et dessinent l’avenir de l’ensemble de notre société.
+
+La République du 21e siècle sera nécessairement numérique : elle doit anticiper les changements à l’œuvre, en saisir pleinement les opportunités, et dessiner une société conforme à ses principes de liberté, d’égalité et de fraternité.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # Projet de loi pour une République numérique
 
-Le numérique et ses usages sont au cœur d’un vaste mouvement de transformation de notre économie, de redéfinition de nos espaces publics et privés, et de construction du lien social. Les conséquences de ces évolutions sont dès à présent globales, et dessinent l’avenir de l’ensemble de notre société.
+Le numérique et ses usages sont au cœur d’un vaste mouvement de transformation de notre économie,
+De redéfinition de nos espaces publics et privés, et de construction du lien social. Les
+Conséquences de ces évolutions sont dès à présent globales, et dessinent l’avenir de l’ensemble de
+Notre société.
 
-La République du 21e siècle sera nécessairement numérique : elle doit anticiper les changements à l’œuvre, en saisir pleinement les opportunités, et dessiner une société conforme à ses principes de liberté, d’égalité et de fraternité.
+La République du 21e siècle sera nécessairement numérique : elle doit anticiper les changements à
+L’œuvre, en saisir pleinement les opportunités, et dessiner une société conforme à ses principes de
+Liberté, d’égalité et de fraternité.

--- a/Titre I/Chapitre II - Economie du savoir.md
+++ b/Titre I/Chapitre II - Economie du savoir.md
@@ -4,69 +4,142 @@ Chapitre II
 
 Article 17 A (nouveau)
 
-À la fin de la seconde phrase de l’article L. 312‑9 du code de l’éducation, les mots : « et le respect de la propriété intellectuelle » sont remplacés par les mots : « , le respect de la propriété intellectuelle et de l’égalité entre les femmes et les hommes ainsi que la lutte contre les violences commises au moyen d’un service de communication au public en ligne ».
+À la fin de la seconde phrase de l’article L. 312‑9 du code de l’éducation, les mots : « et le
+Respect de la propriété intellectuelle » sont remplacés par les mots : « , le respect de la
+Propriété intellectuelle et de l’égalité entre les femmes et les hommes ainsi que la lutte contre
+Les violences commises au moyen d’un service de communication au public en ligne ».
 
 Article 17
 
-Le chapitre III du titre III du livre V du code de la recherche est complété par un article L. 533‑4 ainsi rédigé :
+Le chapitre III du titre III du livre V du code de la recherche est complété par un article L.
+533‑4 ainsi rédigé :
 
-« Art. L. 533‑4. – I. – Lorsqu’un écrit scientifique, issu d’une activité de recherche financée au moins pour moitié par des dotations de l’État, des collectivités territoriales ou des établissements publics, par des subventions d’agences de financement nationales ou par des fonds de l’Union européenne, est publié dans un périodique paraissant au moins une fois par an, son auteur dispose, même après avoir accordé des droits exclusifs à un éditeur, du droit de mettre à disposition gratuitement dans un format ouvert, par voie numérique, sous réserve de l’accord des éventuels coauteurs, toutes les versions successives du manuscrit jusqu’à la version finale acceptée pour publication, dès lors que l’éditeur met lui‑même celle‑ci gratuitement à disposition par voie numérique et, à défaut, à l’expiration d’un délai courant à compter de la date de la première publication. Ce délai est de six mois pour une publication dans le domaine des sciences, de la technique et de la médecine et de douze mois dans celui des sciences humaines et sociales. Un délai inférieur peut être prévu par un arrêté du ministre chargé de la recherche pour certaines disciplines.
+« Art. L. 533‑4. – I. – Lorsqu’un écrit scientifique, issu d’une activité de recherche financée au
+Moins pour moitié par des dotations de l’État, des collectivités territoriales ou des établissements
+Publics, par des subventions d’agences de financement nationales ou par des fonds de l’Union
+Européenne, est publié dans un périodique paraissant au moins une fois par an, son auteur dispose,
+Même après avoir accordé des droits exclusifs à un éditeur, du droit de mettre à disposition
+Gratuitement dans un format ouvert, par voie numérique, sous réserve de l’accord des éventuels
+Coauteurs, toutes les versions successives du manuscrit jusqu’à la version finale acceptée pour
+Publication, dès lors que l’éditeur met lui‑même celle‑ci gratuitement à disposition par voie
+Numérique et, à défaut, à l’expiration d’un délai courant à compter de la date de la première
+Publication. Ce délai est de six mois pour une publication dans le domaine des sciences, de la
+Technique et de la médecine et de douze mois dans celui des sciences humaines et sociales. Un délai
+Inférieur peut être prévu par un arrêté du ministre chargé de la recherche pour certaines
+Disciplines.
 
-« La version mise à disposition en application du premier alinéa ne peut faire l’objet d’une exploitation dans le cadre d’une activité d’édition à caractère commercial.
+« La version mise à disposition en application du premier alinéa ne peut faire l’objet d’une
+Exploitation dans le cadre d’une activité d’édition à caractère commercial.
 
-« II. – Dès lors que les données issues d’une activité de recherche, financée au moins pour moitié par des dotations de l’État, des collectivités territoriales, des établissements publics, des subventions d’agences de financement nationales ou par des fonds de l’Union européenne, ne sont pas protégées par un droit spécifique ou une réglementation particulière et qu’elles ont été rendues publiques par le chercheur, l’établissement ou l’organisme de recherche, leur réutilisation est libre.
+« II. – Dès lors que les données issues d’une activité de recherche, financée au moins pour moitié
+Par des dotations de l’État, des collectivités territoriales, des établissements publics, des
+Subventions d’agences de financement nationales ou par des fonds de l’Union européenne, ne sont pas
+Protégées par un droit spécifique ou une réglementation particulière et qu’elles ont été rendues
+Publiques par le chercheur, l’établissement ou l’organisme de recherche, leur réutilisation est
+Libre.
 
-« III. – L’éditeur d’un écrit scientifique mentionné au I ne peut limiter la réutilisation des données de la recherche rendues publiques dans le cadre de sa publication.
+« III. – L’éditeur d’un écrit scientifique mentionné au I ne peut limiter la réutilisation des
+Données de la recherche rendues publiques dans le cadre de sa publication.
 
-« IV. – Les dispositions du présent article sont d’ordre public et toute clause contraire à celles‑ci est réputée non écrite. »
+« IV. – Les dispositions du présent article sont d’ordre public et toute clause contraire à
+Celles‑ci est réputée non écrite. »
 
 Article 17 bis (nouveau)
 
-La seconde phrase du premier alinéa de l’article L. 611‑8 du code de l’éducation est remplacée par deux phrases ainsi rédigées :
+La seconde phrase du premier alinéa de l’article L. 611‑8 du code de l’éducation est remplacée par
+Deux phrases ainsi rédigées :
 
-« Cette mise à disposition peut se substituer aux enseignements dispensés en présence des étudiants afin de permettre une formation universitaire à distance et une formation continue destinée à la promotion professionnelle de travailleurs et de demandeurs d’emplois éloignés des villes universitaires. Ces formations permettent la délivrance des diplômes universitaires dans des conditions de validation des acquis définies par décret. »
+« Cette mise à disposition peut se substituer aux enseignements dispensés en présence des étudiants
+Afin de permettre une formation universitaire à distance et une formation continue destinée à la
+Promotion professionnelle de travailleurs et de demandeurs d’emplois éloignés des villes
+Universitaires. Ces formations permettent la délivrance des diplômes universitaires dans des
+Conditions de validation des acquis définies par décret. »
 
 Article 17 ter (nouveau)
 
-Le Gouvernement remet au Parlement, au plus tard deux ans après la promulgation de la présente loi, un rapport qui évalue les effets de l’article L. 533‑4 du code de la recherche sur le marché de l’édition scientifique et sur la circulation des idées et des données scientifiques françaises.
+Le Gouvernement remet au Parlement, au plus tard deux ans après la promulgation de la présente
+Loi, un rapport qui évalue les effets de l’article L. 533‑4 du code de la recherche sur le marché de
+L’édition scientifique et sur la circulation des idées et des données scientifiques françaises.
 
 Article 18
 
-Le chapitre IV de la loi n° 78‑17 du 6 janvier 1978 précitée est ainsi modifié :
+Le chapitre IV de la loi n° 78‑17 du 6 janvier 1978 précitée est ainsi modifié :
 
-1° Après le I de l’article 22, il est inséré un I bis ainsi rédigé :
+1° Après le I de l’article 22, il est inséré un I bis ainsi rédigé :
 
-« I bis. – Par dérogation au 1° des I et II de l’article 27, font également l’objet d’une déclaration auprès de la Commission nationale de l’informatique et des libertés les traitements qui portent sur des données à caractère personnel parmi lesquelles figure le numéro d’inscription des personnes au répertoire national d’identification des personnes physiques ou qui requièrent une consultation de ce répertoire, lorsque ces traitements ont exclusivement des finalités de statistique publique, sont mis en œuvre par le service statistique public et ne comportent aucune des données mentionnées au I de l’article 8 ou à l’article 9, à la condition que le numéro d’inscription à ce répertoire ait préalablement fait l’objet d’une opération cryptographique lui substituant un code statistique non signifiant, ainsi que les traitements ayant comme finalité exclusive de réaliser cette opération cryptographique. L’utilisation du code statistique non signifiant n’est autorisée qu’au sein du service statistique public. L’opération cryptographique est renouvelée à une fréquence définie par le décret en Conseil d’État prévu au second alinéa du présent I bis.
+« I bis. – Par dérogation au 1° des I et II de l’article 27, font également l’objet d’une
+Déclaration auprès de la Commission nationale de l’informatique et des libertés les traitements qui
+Portent sur des données à caractère personnel parmi lesquelles figure le numéro d’inscription des
+Personnes au répertoire national d’identification des personnes physiques ou qui requièrent une
+Consultation de ce répertoire, lorsque ces traitements ont exclusivement des finalités de
+Statistique publique, sont mis en œuvre par le service statistique public et ne comportent aucune
+Des données mentionnées au I de l’article 8 ou à l’article 9, à la condition que le numéro
+D’inscription à ce répertoire ait préalablement fait l’objet d’une opération cryptographique lui
+Substituant un code statistique non signifiant, ainsi que les traitements ayant comme finalité
+Exclusive de réaliser cette opération cryptographique. L’utilisation du code statistique non
+Signifiant n’est autorisée qu’au sein du service statistique public. L’opération cryptographique est
+Renouvelée à une fréquence définie par le décret en Conseil d’État prévu au second alinéa du présent
+I bis.
 
-« Un décret en Conseil d’État, pris après avis motivé et publié de la Commission nationale de l’informatique et des libertés, définit les modalités d’application du premier alinéa du présent I bis. » ;
+« Un décret en Conseil d’État, pris après avis motivé et publié de la Commission nationale de
+L’informatique et des libertés, définit les modalités d’application du premier alinéa du présent I
+Bis. » ;
 
-2° Le I de l’article 25 est complété par un 9° ainsi rédigé :
+2° Le I de l’article 25 est complété par un 9° ainsi rédigé :
 
-« 9° Par dérogation au 1° du I et aux 1° et 2° du II de l’article 27, les traitements qui portent sur des données personnelles parmi lesquelles figure le numéro d’inscription des personnes au répertoire national d’identification des personnes physiques ou qui requièrent une consultation de ce répertoire, lorsque ces traitements ont exclusivement des finalités de recherche scientifique ou historique, à la condition que le numéro d’inscription à ce répertoire ait préalablement fait l’objet d’une opération cryptographique lui substituant un code spécifique non signifiant, propre à chaque projet de recherche, ainsi que les traitements ayant comme finalité exclusive de réaliser cette opération cryptographique. L’opération cryptographique et, le cas échéant, l’interconnexion de deux fichiers par l’utilisation du code spécifique non signifiant qui en est issu sont assurées par des personnes distinctes de la personne responsable du traitement.
+« 9° Par dérogation au 1° du I et aux 1° et 2° du II de l’article 27, les traitements qui portent
+Sur des données personnelles parmi lesquelles figure le numéro d’inscription des personnes au
+Répertoire national d’identification des personnes physiques ou qui requièrent une consultation de
+Ce répertoire, lorsque ces traitements ont exclusivement des finalités de recherche scientifique ou
+Historique, à la condition que le numéro d’inscription à ce répertoire ait préalablement fait
+L’objet d’une opération cryptographique lui substituant un code spécifique non signifiant, propre à
+Chaque projet de recherche, ainsi que les traitements ayant comme finalité exclusive de réaliser
+Cette opération cryptographique. L’opération cryptographique et, le cas échéant, l’interconnexion de
+Deux fichiers par l’utilisation du code spécifique non signifiant qui en est issu sont assurées par
+Des personnes distinctes de la personne responsable du traitement.
 
-« Un décret en Conseil d’État, pris après avis motivé et publié de la Commission nationale de l’informatique et des libertés, définit les modalités d’application du présent 9°. » ;
+« Un décret en Conseil d’État, pris après avis motivé et publié de la Commission nationale de
+L’informatique et des libertés, définit les modalités d’application du présent 9°. » ;
 
-3° Au début du 1° des I et II de l’article 27, sont ajoutés les mots : « Sous réserve du I bis de l’article 22 et du 9° du I de l’article 25, ».
+3° Au début du 1° des I et II de l’article 27, sont ajoutés les mots : « Sous réserve du I bis de
+L’article 22 et du 9° du I de l’article 25, ».
 
 Article 18 bis (nouveau)
 
-Le code de la propriété intellectuelle est ainsi modifié :
+Le code de la propriété intellectuelle est ainsi modifié :
 
-1° Après le second alinéa du 9° de l’article L. 122‑5, il est inséré un 10° ainsi rédigé :
+1° Après le second alinéa du 9° de l’article L. 122‑5, il est inséré un 10° ainsi rédigé :
 
-« 10° Les copies ou reproductions numériques réalisées à partir d’une source licite, en vue de l’exploration de textes et de données pour les besoins de la recherche publique, à l’exclusion de toute finalité commerciale. Un décret fixe les conditions dans lesquelles l’exploration des textes et des données est mise en œuvre, ainsi que les modalités de conservation et de communication des fichiers produits au terme des activités de recherche pour lesquelles elles ont été produites ; ces fichiers constituent des données de la recherche. » ;
+« 10° Les copies ou reproductions numériques réalisées à partir d’une source licite, en vue de
+L’exploration de textes et de données pour les besoins de la recherche publique, à l’exclusion de
+Toute finalité commerciale. Un décret fixe les conditions dans lesquelles l’exploration des textes
+Et des données est mise en œuvre, ainsi que les modalités de conservation et de communication des
+Fichiers produits au terme des activités de recherche pour lesquelles elles ont été produites ; ces
+Fichiers constituent des données de la recherche. » ;
 
-2° Après le 4° de l’article L. 342‑3, il est inséré un 5° ainsi rédigé :
+2° Après le 4° de l’article L. 342‑3, il est inséré un 5° ainsi rédigé :
 
-« 5° Les copies ou reproductions numériques de la base réalisées par une personne qui y a licitement accès, en vue de fouilles de textes et de données dans un cadre de recherche, à l’exclusion de toute finalité commerciale. La conservation et la communication des copies techniques issues des traitements, au terme des activités de recherche pour lesquelles elles ont été produites, sont assurées par des organismes désignés par décret. Les autres copies ou reproductions sont détruites. »
+« 5° Les copies ou reproductions numériques de la base réalisées par une personne qui y a
+Licitement accès, en vue de fouilles de textes et de données dans un cadre de recherche, à
+L’exclusion de toute finalité commerciale. La conservation et la communication des copies techniques
+Issues des traitements, au terme des activités de recherche pour lesquelles elles ont été produites,
+Sont assurées par des organismes désignés par décret. Les autres copies ou reproductions sont
+Détruites. »
 
 Article 18 ter (nouveau)
 
-Après le second alinéa du 9° de l’article L. 122‑5 du code de la propriété intellectuelle, il est inséré un 11° ainsi rédigé :
+Après le second alinéa du 9° de l’article L. 122‑5 du code de la propriété intellectuelle, il est
+Inséré un 11° ainsi rédigé :
 
-« 11° Les reproductions et représentations d’œuvres architecturales et de sculptures, placées en permanence sur la voie publique, réalisées par des particuliers à des fins non lucratives. »
+« 11° Les reproductions et représentations d’œuvres architecturales et de sculptures, placées en
+Permanence sur la voie publique, réalisées par des particuliers à des fins non lucratives. »
 
 Article 18 quater (nouveau)
 
-Les outils numériques et de l’internet étant d’usage banalisé, les langages et logiciels facilement accessibles et leurs utilisations en ligne valorisées par les administrations et les pouvoirs publics, leur bon usage est promu, notamment auprès des mineurs et jeunes majeurs en formation, en fonction de leur âge et de leur maturité et tout au long de la vie afin que les opportunités comme les risques inhérents à l’usage de ces technologies puissantes soient connus de tous.
+Les outils numériques et de l’internet étant d’usage banalisé, les langages et logiciels
+Facilement accessibles et leurs utilisations en ligne valorisées par les administrations et les
+Pouvoirs publics, leur bon usage est promu, notamment auprès des mineurs et jeunes majeurs en
+Formation, en fonction de leur âge et de leur maturité et tout au long de la vie afin que les
+Opportunités comme les risques inhérents à l’usage de ces technologies puissantes soient connus de
+Tous.
 

--- a/Titre I/Chapitre II - Economie du savoir.md
+++ b/Titre I/Chapitre II - Economie du savoir.md
@@ -1,15 +1,15 @@
-Chapitre II
+## Chapitre II
 
 Économie du savoir
 
-Article 17 A (nouveau)
+#### Article 17 A (nouveau)
 
 À la fin de la seconde phrase de l’article L. 312‑9 du code de l’éducation, les mots : « et le
 Respect de la propriété intellectuelle » sont remplacés par les mots : « , le respect de la
 Propriété intellectuelle et de l’égalité entre les femmes et les hommes ainsi que la lutte contre
 Les violences commises au moyen d’un service de communication au public en ligne ».
 
-Article 17
+#### Article 17
 
 Le chapitre III du titre III du livre V du code de la recherche est complété par un article L.
 533‑4 ainsi rédigé :
@@ -44,7 +44,7 @@ Données de la recherche rendues publiques dans le cadre de sa publication.
 « IV. – Les dispositions du présent article sont d’ordre public et toute clause contraire à
 Celles‑ci est réputée non écrite. »
 
-Article 17 bis (nouveau)
+#### Article 17 bis (nouveau)
 
 La seconde phrase du premier alinéa de l’article L. 611‑8 du code de l’éducation est remplacée par
 Deux phrases ainsi rédigées :
@@ -55,13 +55,13 @@ Promotion professionnelle de travailleurs et de demandeurs d’emplois éloigné
 Universitaires. Ces formations permettent la délivrance des diplômes universitaires dans des
 Conditions de validation des acquis définies par décret. »
 
-Article 17 ter (nouveau)
+#### Article 17 ter (nouveau)
 
 Le Gouvernement remet au Parlement, au plus tard deux ans après la promulgation de la présente
 Loi, un rapport qui évalue les effets de l’article L. 533‑4 du code de la recherche sur le marché de
 L’édition scientifique et sur la circulation des idées et des données scientifiques françaises.
 
-Article 18
+#### Article 18
 
 Le chapitre IV de la loi n° 78‑17 du 6 janvier 1978 précitée est ainsi modifié :
 
@@ -104,7 +104,7 @@ L’informatique et des libertés, définit les modalités d’application du pr
 3° Au début du 1° des I et II de l’article 27, sont ajoutés les mots : « Sous réserve du I bis de
 L’article 22 et du 9° du I de l’article 25, ».
 
-Article 18 bis (nouveau)
+#### Article 18 bis (nouveau)
 
 Le code de la propriété intellectuelle est ainsi modifié :
 
@@ -126,7 +126,7 @@ Issues des traitements, au terme des activités de recherche pour lesquelles ell
 Sont assurées par des organismes désignés par décret. Les autres copies ou reproductions sont
 Détruites. »
 
-Article 18 ter (nouveau)
+#### Article 18 ter (nouveau)
 
 Après le second alinéa du 9° de l’article L. 122‑5 du code de la propriété intellectuelle, il est
 Inséré un 11° ainsi rédigé :
@@ -134,7 +134,7 @@ Inséré un 11° ainsi rédigé :
 « 11° Les reproductions et représentations d’œuvres architecturales et de sculptures, placées en
 Permanence sur la voie publique, réalisées par des particuliers à des fins non lucratives. »
 
-Article 18 quater (nouveau)
+#### Article 18 quater (nouveau)
 
 Les outils numériques et de l’internet étant d’usage banalisé, les langages et logiciels
 Facilement accessibles et leurs utilisations en ligne valorisées par les administrations et les

--- a/Titre I/Chapitre Ier - Economie de la donnée.md
+++ b/Titre I/Chapitre Ier - Economie de la donnée.md
@@ -1,6 +1,6 @@
-titre I<sup>er</sup>
+Titre I<sup>er</sup>
 
-la circulation des donnÉes et du savoir
+La circulation des donnÉes et du savoir
 
 Chapitre I<sup>er</sup>
 
@@ -12,205 +12,344 @@ Ouverture de l’accès aux données publiques
 
 Article 1<sup>er</sup>
 
-I. – Sous réserve des articles L. 311‑5 et L. 311‑6 du code des relations entre le public et l’administration et sans préjudice de l’article L. 114‑8 du même code, les administrations mentionnées au premier alinéa de l’article L. 300‑2 dudit code sont tenues de communiquer, dans le respect de la loi n° 78‑17 du 6 janvier 1978 relative à l’informatique, aux fichiers et aux libertés, les documents administratifs qu’elles détiennent aux autres administrations mentionnées au même premier alinéa de l’article L. 300‑2 qui en font la demande pour l’accomplissement de leurs missions de service public.
+I. – Sous réserve des articles L. 311‑5 et L. 311‑6 du code des relations entre le public et
+L’administration et sans préjudice de l’article L. 114‑8 du même code, les administrations
+Mentionnées au premier alinéa de l’article L. 300‑2 dudit code sont tenues de communiquer, dans le
+Respect de la loi n° 78‑17 du 6 janvier 1978 relative à l’informatique, aux fichiers et aux
+Libertés, les documents administratifs qu’elles détiennent aux autres administrations mentionnées au
+Même premier alinéa de l’article L. 300‑2 qui en font la demande pour l’accomplissement de leurs
+Missions de service public.
 
-Les informations figurant dans des documents administratifs communiqués ou publiés peuvent être utilisées par toute administration mentionnée au premier alinéa de l’article L. 300‑2 qui le souhaite à des fins d’accomplissement de missions de service public autres que celle pour les besoins de laquelle les documents ont été produits ou reçus.
+Les informations figurant dans des documents administratifs communiqués ou publiés peuvent être
+Utilisées par toute administration mentionnée au premier alinéa de l’article L. 300‑2 qui le
+Souhaite à des fins d’accomplissement de missions de service public autres que celle pour les
+Besoins de laquelle les documents ont été produits ou reçus.
 
-À compter du 1<sup>er</sup> janvier 2017, l’échange d’informations publiques entre les administrations de l’État et entre l’État et ses établissements publics administratifs, aux fins de l’exercice de leur mission de service public, ne peut donner lieu au versement d’une redevance.
+À compter du 1<sup>er</sup> janvier 2017, l’échange d’informations publiques entre les
+Administrations de l’État et entre l’État et ses établissements publics administratifs, aux fins de
+L’exercice de leur mission de service public, ne peut donner lieu au versement d’une redevance.
 
-II à IV (nouveaux). – (Supprimés)
+II à IV (nouveaux). – (Supprimés)
 
-V (nouveau). – Le A de l’article L. 342‑2 du code des relations entre le public et l’administration est complété par un 22° ainsi rédigé :
+V (nouveau). – Le A de l’article L. 342‑2 du code des relations entre le public et
+L’administration est complété par un 22° ainsi rédigé :
 
-« 22° L’article 1<sup>er</sup> de la loi n°     du      pour une République numérique. »
+« 22° L’article 1<sup>er</sup> de la loi n° du pour une République numérique. »
 
-VI (nouveau). – Le titre I<sup>er</sup> du livre III du code des relations entre le public et l’administration est applicable aux demandes de communication des documents administratifs exercées en application du I du présent article.
+VI (nouveau). – Le titre I<sup>er</sup> du livre III du code des relations entre le public et
+L’administration est applicable aux demandes de communication des documents administratifs exercées
+En application du I du présent article.
 
-Article 1<sup>er</sup> bis A (nouveau)
+Article 1<sup>er</sup> bis A (nouveau)
 
-Le Gouvernement remet au Parlement, au plus tard le 30 juin 2016, un rapport sur la nécessité de créer une consultation publique en ligne pour tout projet de loi ou proposition de loi avant son inscription à l’ordre du jour du Parlement.
+Le Gouvernement remet au Parlement, au plus tard le 30 juin 2016, un rapport sur la nécessité de
+Créer une consultation publique en ligne pour tout projet de loi ou proposition de loi avant son
+Inscription à l’ordre du jour du Parlement.
 
 Article 1<sup>er</sup> bis (nouveau)
 
-I. – À la seconde phrase du premier alinéa de l’article L. 300‑2 du code des relations entre le public et l’administration, après le mot : « prévisions », sont insérés les mots : « , codes sources ».
+I. – À la seconde phrase du premier alinéa de l’article L. 300‑2 du code des relations entre le
+Public et l’administration, après le mot : « prévisions », sont insérés les mots : « , codes sources
+».
 
-II (nouveau). – À la fin du d du 2° de l’article L. 311‑5 du même code, les mots : « ou à la sécurité des personnes » sont remplacés par les mots : « , à la sécurité des personnes ou à la sécurité des systèmes d’information des administrations ».
+II (nouveau). – À la fin du d du 2° de l’article L. 311‑5 du même code, les mots : « ou à la
+Sécurité des personnes » sont remplacés par les mots : « , à la sécurité des personnes ou à la
+Sécurité des systèmes d’information des administrations ».
 
 Article 1<sup>er</sup> ter (nouveau)
 
-Le chapitre I<sup>er</sup> du titre I<sup>er</sup> du livre III du code des relations entre le public et l’administration est ainsi modifié :
+Le chapitre I<sup>er</sup> du titre I<sup>er</sup> du livre III du code des relations entre le
+Public et l’administration est ainsi modifié :
 
-1° Au premier alinéa de l’article L. 311‑1, après le mot : « tenues », sont insérés les mots : « de publier en ligne dans un format ouvert et aisément réutilisable ou » ;
+1° Au premier alinéa de l’article L. 311‑1, après le mot : « tenues », sont insérés les mots : «
+De publier en ligne dans un format ouvert et aisément réutilisable ou » ;
 
-s2° L’article L. 311‑9 est complété par un 4° ainsi rédigé :
+S2° L’article L. 311‑9 est complété par un 4° ainsi rédigé :
 
-« 4° Par publication des informations en ligne dans un format ouvert et aisément réutilisable. »
+« 4° Par publication des informations en ligne dans un format ouvert et aisément réutilisable. »
 
 Article 2
 
-Après l’article L. 311‑3 du code des relations entre le public et l’administration, il est inséré un article L. 311‑3‑1 ainsi rédigé :
+Après l’article L. 311‑3 du code des relations entre le public et l’administration, il est inséré
+Un article L. 311‑3‑1 ainsi rédigé :
 
-« Art. L. 311‑3‑1. – Sous réserve de l’application du 2° de l’article L. 311‑5, lorsqu’une décision individuelle est prise sur le fondement d’un traitement algorithmique, les règles définissant ce traitement ainsi que les principales caractéristiques de sa mise en œuvre sont communiquées par l’administration à l’intéressé s’il en fait la demande.
+« Art. L. 311‑3‑1. – Sous réserve de l’application du 2° de l’article L. 311‑5, lorsqu’une décision
+Individuelle est prise sur le fondement d’un traitement algorithmique, les règles définissant ce
+Traitement ainsi que les principales caractéristiques de sa mise en œuvre sont communiquées par
+L’administration à l’intéressé s’il en fait la demande.
 
-« Les conditions d’application du présent article sont fixées par décret en Conseil d’État. »
+« Les conditions d’application du présent article sont fixées par décret en Conseil d’État. »
 
 Article 2 bis (nouveau)
 
-Au 1° de l’article L. 311‑5 du code des relations entre le public et l’administration, la première occurrence du mot : « et » est remplacée par les mots : « qui ne portent pas sur un projet de loi ou d’ordonnance, les avis ».
+Au 1° de l’article L. 311‑5 du code des relations entre le public et l’administration, la première
+Occurrence du mot : « et » est remplacée par les mots : « qui ne portent pas sur un projet de loi ou
+D’ordonnance, les avis ».
 
 Article 3
 
-Le deuxième alinéa de l’article L. 312‑1 du code des relations entre le public et l’administration est supprimé.
+Le deuxième alinéa de l’article L. 312‑1 du code des relations entre le public et l’administration
+Est supprimé.
 
 Article 4
 
-I A (nouveau). – Le 1° de l’article L. 311‑6 du code des relations entre le public et l’administration est complété par les mots : « , lequel comprend le secret des procédés, des informations économiques et financières et des stratégies commerciales ou industrielles et est apprécié en tenant compte, le cas échéant, du fait que la mission de service public de l’administration mentionnée au premier alinéa de l’article L. 300‑2 est soumise à la concurrence ».
+I A (nouveau). – Le 1° de l’article L. 311‑6 du code des relations entre le public et
+L’administration est complété par les mots : « , lequel comprend le secret des procédés, des
+Informations économiques et financières et des stratégies commerciales ou industrielles et est
+Apprécié en tenant compte, le cas échéant, du fait que la mission de service public de
+L’administration mentionnée au premier alinéa de l’article L. 300‑2 est soumise à la concurrence ».
 
-I. – La section 1 du chapitre II du titre I<sup>er</sup> du livre III du code des relations entre le public et l’administration est complétée par des articles L. 312‑1‑1 à L. 312‑1‑3 ainsi rédigés :
+I. – La section 1 du chapitre II du titre I<sup>er</sup> du livre III du code des relations entre
+Le public et l’administration est complétée par des articles L. 312‑1‑1 à L. 312‑1‑3 ainsi rédigés :
 
-« Art. L. 312‑1‑1. – Sous réserve des articles L. 311‑5 et L. 311‑6 et lorsque ces documents sont disponibles sous forme électronique, les administrations mentionnées au premier alinéa de l’article L. 300‑2, à l’exception des personnes morales dont le nombre d’agents ou de salariés est inférieur à un seuil qui ne peut être supérieur à cinquante agents ou salariés, fixé par décret, publient en ligne, dans un standard ouvert aisément réutilisable, c’est-à-dire lisible par une machine, les documents administratifs suivants :
+« Art. L. 312‑1‑1. – Sous réserve des articles L. 311‑5 et L. 311‑6 et lorsque ces documents sont
+Disponibles sous forme électronique, les administrations mentionnées au premier alinéa de l’article
+L. 300‑2, à l’exception des personnes morales dont le nombre d’agents ou de salariés est inférieur à
+Un seuil qui ne peut être supérieur à cinquante agents ou salariés, fixé par décret, publient en
+Ligne, dans un standard ouvert aisément réutilisable, c’est-à-dire lisible par une machine, les
+Documents administratifs suivants :
 
-« 1° Les documents qu’elles communiquent en application des procédures prévues au présent titre, ainsi que leurs versions mises à jour ;
+« 1° Les documents qu’elles communiquent en application des procédures prévues au présent titre,
+Ainsi que leurs versions mises à jour ;
 
-« 2° Les documents qui figurent dans le répertoire mentionné à l’article 17 de la loi n° 78‑753 du 17 juillet 1978 portant diverses mesures d’amélioration des relations entre l’administration et le public et diverses dispositions d’ordre administratif, social et fiscal ;
+« 2° Les documents qui figurent dans le répertoire mentionné à l’article 17 de la loi n° 78‑753 du
+17 juillet 1978 portant diverses mesures d’amélioration des relations entre l’administration et le
+Public et diverses dispositions d’ordre administratif, social et fiscal ;
 
-« 3° Les bases de données, mises à jour de façon régulière, qu’elles produisent ou qu’elles reçoivent et qui ne font pas l’objet par ailleurs d’une diffusion publique dans un standard ouvert aisément réutilisable, c’est-à-dire lisible par une machine ;
+« 3° Les bases de données, mises à jour de façon régulière, qu’elles produisent ou qu’elles
+Reçoivent et qui ne font pas l’objet par ailleurs d’une diffusion publique dans un standard ouvert
+Aisément réutilisable, c’est-à-dire lisible par une machine ;
 
-« 4° Les données, mises à jour de façon régulière, dont la publication présente un intérêt économique, social, sanitaire ou environnemental.
+« 4° Les données, mises à jour de façon régulière, dont la publication présente un intérêt
+économique, social, sanitaire ou environnemental.
 
-« Le présent article ne s’applique pas aux collectivités territoriales de moins de 3 500 habitants.
+« Le présent article ne s’applique pas aux collectivités territoriales de moins de 3 500 habitants.
 
-« Art. L. 312‑1‑2. – Sauf dispositions législatives ou réglementaires contraires, lorsque les documents et données mentionnés aux articles L. 312‑1 ou L. 312‑1‑1 comportent des mentions entrant dans le champ d’application des articles L. 311‑5 ou L. 311‑6, ils ne peuvent être rendus publics qu’après avoir fait l’objet d’un traitement permettant d’occulter ces mentions.
+« Art. L. 312‑1‑2. – Sauf dispositions législatives ou réglementaires contraires, lorsque les
+Documents et données mentionnés aux articles L. 312‑1 ou L. 312‑1‑1 comportent des mentions entrant
+Dans le champ d’application des articles L. 311‑5 ou L. 311‑6, ils ne peuvent être rendus publics
+Qu’après avoir fait l’objet d’un traitement permettant d’occulter ces mentions.
 
-« Sauf dispositions législatives ou réglementaires contraires ou si les personnes intéressées ont donné leur accord, lorsque les documents et données mentionnés aux articles L. 312‑1 ou L. 312‑1‑1 comportent des données à caractère personnel, ils ne peuvent être rendus publics qu’après avoir fait l’objet d’un traitement permettant de rendre impossible l’identification de ces personnes.
+« Sauf dispositions législatives ou réglementaires contraires ou si les personnes intéressées ont
+Donné leur accord, lorsque les documents et données mentionnés aux articles L. 312‑1 ou L. 312‑1‑1
+Comportent des données à caractère personnel, ils ne peuvent être rendus publics qu’après avoir fait
+L’objet d’un traitement permettant de rendre impossible l’identification de ces personnes.
 
-« Les administrations mentionnées au premier alinéa de l’article L. 300‑2 ne sont pas tenues de publier les archives publiques issues des opérations de sélection prévues aux articles L. 212‑2 et L. 212‑3 du code du patrimoine lorsque ces archives ne sont pas disponibles sous forme électronique.
+« Les administrations mentionnées au premier alinéa de l’article L. 300‑2 ne sont pas tenues de
+Publier les archives publiques issues des opérations de sélection prévues aux articles L. 212‑2 et
+L. 212‑3 du code du patrimoine lorsque ces archives ne sont pas disponibles sous forme électronique.
 
-« Art. L. 312-1-3 (nouveau). – Les administrations mentionnées au premier alinéa de l’article L. 300‑2, à l’exception des personnes morales dont le nombre d’agents ou de salariés est inférieur à un seuil qui ne peut être supérieur à cinquante agents ou salariés, fixé par décret, rendent publics en ligne, dans un standard ouvert et aisément réutilisable, les règles définissant les principaux traitements algorithmiques utilisés dans l’accomplissement de leurs missions lorsqu’ils fondent des décisions individuelles. »
+« Art. L. 312-1-3 (nouveau). – Les administrations mentionnées au premier alinéa de l’article L.
+300‑2, à l’exception des personnes morales dont le nombre d’agents ou de salariés est inférieur à un
+Seuil qui ne peut être supérieur à cinquante agents ou salariés, fixé par décret, rendent publics en
+Ligne, dans un standard ouvert et aisément réutilisable, les règles définissant les principaux
+Traitements algorithmiques utilisés dans l’accomplissement de leurs missions lorsqu’ils fondent des
+Décisions individuelles. »
 
-II. – Un décret en Conseil d’État, pris après avis de la commission mentionnée à l’article L. 340‑1 du code des relations entre le public et l’administration, définit les modalités d’application des articles L. 312‑1 à L. 312‑1‑3 du même code.
+II. – Un décret en Conseil d’État, pris après avis de la commission mentionnée à l’article L.
+340‑1 du code des relations entre le public et l’administration, définit les modalités d’application
+Des articles L. 312‑1 à L. 312‑1‑3 du même code.
 
-III (nouveau). – L’article L. 1112‑23 du code général des collectivités territoriales et l’article L. 125‑12 du code des communes de la Nouvelle‑Calédonie sont abrogés.
+III (nouveau). – L’article L. 1112‑23 du code général des collectivités territoriales et l’article
+L. 125‑12 du code des communes de la Nouvelle‑Calédonie sont abrogés.
 
 Article 4 bis (nouveau)
 
-Après le 7° du II de l’article L. 541‑10 du code de l’environnement, il est inséré un 8° ainsi rédigé :
+Après le 7° du II de l’article L. 541‑10 du code de l’environnement, il est inséré un 8° ainsi
+Rédigé :
 
-« 8° Les conditions dans lesquelles sont encouragées les démarches d’ouverture des données relatives au domaine des déchets ; ».
+« 8° Les conditions dans lesquelles sont encouragées les démarches d’ouverture des données
+Relatives au domaine des déchets ; ».
 
 Article 5
 
-I. – À l’article L. 311‑4 du code des relations entre le public et l’administration, après le mot : « communiqués », sont insérés les mots : « ou publiés ».
+I. – À l’article L. 311‑4 du code des relations entre le public et l’administration, après le mot
+: « communiqués », sont insérés les mots : « ou publiés ».
 
-II. – La publication en ligne prévue à l’article L. 312‑1‑1 du code des relations entre le public et l’administration est effectuée :
+II. – La publication en ligne prévue à l’article L. 312‑1‑1 du code des relations entre le public
+Et l’administration est effectuée :
 
-1° Six mois après la promulgation de la présente loi, pour les documents mentionnés au 1° du même article L. 312‑1‑1 ;
+1° Six mois après la promulgation de la présente loi, pour les documents mentionnés au 1° du même
+Article L. 312‑1‑1 ;
 
-2° Un an après la promulgation de la présente loi, pour les documents mentionnés au 2° dudit article L. 312‑1‑1 ;
+2° Un an après la promulgation de la présente loi, pour les documents mentionnés au 2° dudit
+Article L. 312‑1‑1 ;
 
-3° À une date fixée par décret, et au plus tard deux ans après la promulgation de la présente loi, pour l’ensemble des autres documents entrant dans le champ d’application du même article L. 312‑1‑1.
+3° À une date fixée par décret, et au plus tard deux ans après la promulgation de la présente loi,
+Pour l’ensemble des autres documents entrant dans le champ d’application du même article L. 312‑1‑1.
 
 Article 6
 
-I. – L’article 10 de la loi n° 78‑753 du 17 juillet 1978 portant diverses mesures d’amélioration des relations entre l’administration et le public et diverses dispositions d’ordre administratif, social et fiscal est ainsi modifié :
+I. – L’article 10 de la loi n° 78‑753 du 17 juillet 1978 portant diverses mesures d’amélioration
+Des relations entre l’administration et le public et diverses dispositions d’ordre administratif,
+Social et fiscal est ainsi modifié :
 
-1° Le premier alinéa est ainsi rédigé :
+1° Le premier alinéa est ainsi rédigé :
 
-« Les informations publiques figurant dans des documents administratifs communiqués ou publiés peuvent être utilisées par toute personne qui le souhaite à d’autres fins que celles de la mission de service public pour les besoins de laquelle ces documents ont été produits ou reçus. Les limites et conditions de cette réutilisation sont régies par le présent chapitre. Lorsqu’elles sont mises à disposition sous forme électronique, ces informations le sont dans un standard ouvert et aisément réutilisable, c’est‑à‑dire lisible par une machine. » ;
+« Les informations publiques figurant dans des documents administratifs communiqués ou publiés
+Peuvent être utilisées par toute personne qui le souhaite à d’autres fins que celles de la mission
+De service public pour les besoins de laquelle ces documents ont été produits ou reçus. Les limites
+Et conditions de cette réutilisation sont régies par le présent chapitre. Lorsqu’elles sont mises à
+Disposition sous forme électronique, ces informations le sont dans un standard ouvert et aisément
+Réutilisable, c’est‑à‑dire lisible par une machine. » ;
 
-1° bis (nouveau) Au a, après la référence : « chapitre I<sup>er</sup> », sont insérés les mots : « du titre I<sup>er</sup> du livre III du code des relations entre le public et l’administration » ;
+1° bis (nouveau) Au a, après la référence : « chapitre I<sup>er</sup> », sont insérés les mots : «
+Du titre I<sup>er</sup> du livre III du code des relations entre le public et l’administration » ;
 
-2° Le b est abrogé ;
+2° Le b est abrogé ;
 
-3° Au dernier alinéa du c, qui devient le b, la référence : « à l’article 1<sup>er</sup> » est remplacée par la référence : « au premier alinéa de l’article L. 300‑2 du code des relations entre le public et l’administration ».
+3° Au dernier alinéa du c, qui devient le b, la référence : « à l’article 1<sup>er</sup> » est
+Remplacée par la référence : « au premier alinéa de l’article L. 300‑2 du code des relations entre
+Le public et l’administration ».
 
-I bis (nouveau). – À l’avant-dernier alinéa de l’article 14 de la même loi, la référence : « à l’article 1<sup>er </sup>» est remplacée par la référence : « au premier alinéa de l’article L. 300‑2 du code des relations entre le public et l’administration ».
+I bis (nouveau). – À l’avant-dernier alinéa de l’article 14 de la même loi, la référence : « à
+L’article 1<sup>er </sup>» est remplacée par la référence : « au premier alinéa de l’article L.
+300‑2 du code des relations entre le public et l’administration ».
 
-II (nouveau). – À la seconde phrase du premier alinéa du I de l’article 15 de la même loi, la référence : « à l’article 1<sup>er</sup> » est remplacée par la référence : « au premier alinéa de l’article L. 300‑2 du code des relations entre le public et l’administration ».
+II (nouveau). – À la seconde phrase du premier alinéa du I de l’article 15 de la même loi, la
+Référence : « à l’article 1<sup>er</sup> » est remplacée par la référence : « au premier alinéa de
+L’article L. 300‑2 du code des relations entre le public et l’administration ».
 
 Article 6 bis (nouveau)
 
-Le premier alinéa de l’article L. 300‑2 du code des relations entre le public et l’administration est complété par une phrase ainsi rédigée :
+Le premier alinéa de l’article L. 300‑2 du code des relations entre le public et l’administration
+Est complété par une phrase ainsi rédigée :
 
-« Constituent également de tels documents les documents relatifs à la gestion du domaine privé de l’État et des collectivités territoriales. »
+« Constituent également de tels documents les documents relatifs à la gestion du domaine privé de
+L’État et des collectivités territoriales. »
 
 Article 7
 
-La loi n° 78‑753 du 17 juillet 1978 précitée est ainsi modifiée :
+La loi n° 78‑753 du 17 juillet 1978 précitée est ainsi modifiée :
 
-1° L’article 11 est ainsi rétabli :
+1° L’article 11 est ainsi rétabli :
 
-« Art. 11. – Sous réserve de droits de propriété intellectuelle détenus par des tiers, les droits des administrations mentionnées au premier alinéa de l’article L. 300‑2 du code des relations entre le public et l’administration, au titre des articles L. 342‑1 et L. 342‑2 du code de la propriété intellectuelle, ne peuvent faire obstacle à la réutilisation, au sens de l’article 10 de la présente loi, du contenu des bases de données que ces administrations publient en application du 3° de l’article L. 312‑1‑1 du code des relations entre le public et l’administration.
+« Art. 11. – Sous réserve de droits de propriété intellectuelle détenus par des tiers, les droits
+Des administrations mentionnées au premier alinéa de l’article L. 300‑2 du code des relations entre
+Le public et l’administration, au titre des articles L. 342‑1 et L. 342‑2 du code de la propriété
+Intellectuelle, ne peuvent faire obstacle à la réutilisation, au sens de l’article 10 de la présente
+Loi, du contenu des bases de données que ces administrations publient en application du 3° de
+L’article L. 312‑1‑1 du code des relations entre le public et l’administration.
 
-« Le premier alinéa du présent article n’est pas applicable aux bases de données produites ou reçues par les administrations mentionnées au premier alinéa de l’article L. 300‑2 du code des relations entre le public et l’administration dans l’exercice d’une mission de service public à caractère industriel ou commercial soumise à la concurrence. » ;
+« Le premier alinéa du présent article n’est pas applicable aux bases de données produites ou
+Reçues par les administrations mentionnées au premier alinéa de l’article L. 300‑2 du code des
+Relations entre le public et l’administration dans l’exercice d’une mission de service public à
+Caractère industriel ou commercial soumise à la concurrence. » ;
 
-2° L’article 16 est complété par un alinéa ainsi rédigé :
+2° L’article 16 est complété par un alinéa ainsi rédigé :
 
-« Lorsque la réutilisation à titre gratuit donne lieu à l’établissement d’une licence, cette licence est choisie parmi celles figurant sur une liste fixée par décret, qui est révisée tous les cinq ans, après concertation avec les collectivités territoriales et leurs groupements. Lorsqu’une administration souhaite recourir à une licence ne figurant pas sur cette liste, cette licence doit être préalablement homologuée par l’État, dans des conditions fixées par décret. »
+« Lorsque la réutilisation à titre gratuit donne lieu à l’établissement d’une licence, cette
+Licence est choisie parmi celles figurant sur une liste fixée par décret, qui est révisée tous les
+Cinq ans, après concertation avec les collectivités territoriales et leurs groupements. Lorsqu’une
+Administration souhaite recourir à une licence ne figurant pas sur cette liste, cette licence doit
+être préalablement homologuée par l’État, dans des conditions fixées par décret. »
 
 Article 7 bis (nouveau)
 
-I. – L’article 15 de la loi n° 78‑753 du 17 juillet 1978 précitée est complété par un IV ainsi rédigé :
+I. – L’article 15 de la loi n° 78‑753 du 17 juillet 1978 précitée est complété par un IV ainsi
+Rédigé :
 
-« IV. – La réutilisation des informations publiques produites par le service statistique public mentionné à l’article 1<sup>er</sup> de la loi n° 51‑711 du 7 juin 1951 sur l’obligation, la coordination et le secret en matière de statistiques ne peut donner lieu au versement d’une redevance. »
+« IV. – La réutilisation des informations publiques produites par le service statistique public
+Mentionné à l’article 1<sup>er</sup> de la loi n° 51‑711 du 7 juin 1951 sur l’obligation, la
+Coordination et le secret en matière de statistiques ne peut donner lieu au versement d’une
+Redevance. »
 
-II. – Le I du présent article entre en vigueur le 1<sup>er</sup> janvier 2017.
+II. – Le I du présent article entre en vigueur le 1<sup>er</sup> janvier 2017.
 
 Article 8
 
-I. – Le premier alinéa de l’article 17 de la loi n° 78‑753 du 17 juillet 1978 précitée est complété par une phrase ainsi rédigée :
+I. – Le premier alinéa de l’article 17 de la loi n° 78‑753 du 17 juillet 1978 précitée est
+Complété par une phrase ainsi rédigée :
 
-« Elles publient chaque année une version mise à jour de ce répertoire. »
+« Elles publient chaque année une version mise à jour de ce répertoire. »
 
-I bis (nouveau). – Le quatrième alinéa de l’article 18 de la même loi est ainsi modifié :
+I bis (nouveau). – Le quatrième alinéa de l’article 18 de la même loi est ainsi modifié :
 
-1° À la fin de la première phrase, le montant : « 150 000 euros » est remplacé par le montant : « un million d’euros » ;
+1° À la fin de la première phrase, le montant : « 150 000 euros » est remplacé par le montant : «
+Un million d’euros » ;
 
-2° À la seconde phrase, le montant : « 300 000 euros » est remplacé, deux fois, par le montant : « deux millions d’euros ».
+2° À la seconde phrase, le montant : « 300 000 euros » est remplacé, deux fois, par le montant : «
+Deux millions d’euros ».
 
-II. – Le titre IV du livre III du code des relations entre le public et l’administration est ainsi modifié :
+II. – Le titre IV du livre III du code des relations entre le public et l’administration est ainsi
+Modifié :
 
-1° Au premier alinéa de l’article L. 342‑1, après les mots : « refus de communication », sont insérés les mots : « ou un refus de publication » ;
+1° Au premier alinéa de l’article L. 342‑1, après les mots : « refus de communication », sont
+Insérés les mots : « ou un refus de publication » ;
 
-2° Au 3° du A de l’article L. 342‑2, après le mot : « articles », est insérée la référence : « L. 1112‑23, » ;
+2° Au 3° du A de l’article L. 342‑2, après le mot : « articles », est insérée la référence : « L.
+1112‑23, » ;
 
-3° La seconde phrase du dernier alinéa de l’article L. 341‑1 est complétée par les mots : « ou déléguer à son président l’exercice de certaines de ses attributions » ;
+3° La seconde phrase du dernier alinéa de l’article L. 341‑1 est complétée par les mots : « ou
+Déléguer à son président l’exercice de certaines de ses attributions » ;
 
-4° (nouveau) L’article L. 342‑3 du même code est complété par un alinéa ainsi rédigé :
+4° (nouveau) L’article L. 342‑3 du même code est complété par un alinéa ainsi rédigé :
 
-« Lorsqu’une administration confirme une décision de refus de communication ou de publication malgré un avis favorable de la commission, le président de la commission inscrit sur une liste qu’il met en ligne le nom de l’administration, la référence du document administratif non communiqué ou non publié et, le cas échéant, le motif du refus. L’inscription sur la liste cesse dès que l’administration a communiqué ou publié le document ou dès qu’une décision juridictionnelle a rejeté le recours dirigé contre le refus de communication ou de publication. » ;
+« Lorsqu’une administration confirme une décision de refus de communication ou de publication
+Malgré un avis favorable de la commission, le président de la commission inscrit sur une liste qu’il
+Met en ligne le nom de l’administration, la référence du document administratif non communiqué ou
+Non publié et, le cas échéant, le motif du refus. L’inscription sur la liste cesse dès que
+L’administration a communiqué ou publié le document ou dès qu’une décision juridictionnelle a rejeté
+Le recours dirigé contre le refus de communication ou de publication. » ;
 
-5° (nouveau) Le chapitre II est complété par un article L. 342‑6 ainsi rédigé :
+5° (nouveau) Le chapitre II est complété par un article L. 342‑6 ainsi rédigé :
 
-« Art. L. 342‑6. – Lorsque la commission est consultée sur un projet de loi ou de décret, son avis est rendu public. »
+« Art. L. 342‑6. – Lorsque la commission est consultée sur un projet de loi ou de décret, son avis
+Est rendu public. »
 
 Article 9
 
-I. – Au titre II du livre III du code des relations entre le public et l’administration, il est inséré un article L. 321‑1 ainsi rédigé :
+I. – Au titre II du livre III du code des relations entre le public et l’administration, il est
+Inséré un article L. 321‑1 ainsi rédigé :
 
-« Art. L. 321‑1. – I. – La mise à disposition et la publication des données de référence en vue de faciliter leur réutilisation constitue une mission de service public relevant de l’État. Toutes les autorités administratives concourent à cette mission.
+« Art. L. 321‑1. – I. – La mise à disposition et la publication des données de référence en vue de
+Faciliter leur réutilisation constitue une mission de service public relevant de l’État. Toutes les
+Autorités administratives concourent à cette mission.
 
-« II. – Sont des données de référence les informations publiques mentionnées à l’article 10 de la loi n° 78-753 du 17 juillet 1978 précitée qui satisfont aux conditions suivantes :
+« II. – Sont des données de référence les informations publiques mentionnées à l’article 10 de la
+Loi n° 78-753 du 17 juillet 1978 précitée qui satisfont aux conditions suivantes :
 
-« 1° Elles constituent une référence commune pour nommer ou identifier des produits, des services, des territoires ou des personnes ;
+« 1° Elles constituent une référence commune pour nommer ou identifier des produits, des services,
+Des territoires ou des personnes ;
 
-« 2° Elles sont réutilisées fréquemment par des personnes publiques ou privées autres que l’administration qui les détient ;
+« 2° Elles sont réutilisées fréquemment par des personnes publiques ou privées autres que
+L’administration qui les détient ;
 
-« 3° Leurs réutilisations nécessitent qu’elles soient mises à disposition avec un niveau élevé de qualité, notamment en termes de précision, de disponibilité ou de fréquence de mise à jour.
+« 3° Leurs réutilisations nécessitent qu’elles soient mises à disposition avec un niveau élevé de
+Qualité, notamment en termes de précision, de disponibilité ou de fréquence de mise à jour.
 
-« III. – Les modalités d’application du présent article sont définies par un décret en Conseil d’État. Lorsque plusieurs administrations sont responsables, le décret détermine les modalités de la coordination entre ces administrations. Il détermine la liste des données de référence et désigne les administrations responsables de leur production et de leur publication. Il fixe la qualité minimale que la publication des données de référence doit respecter, notamment en termes de précision, de degré de détail, de fréquence de mise à jour, d’accessibilité et de format. »
+« III. – Les modalités d’application du présent article sont définies par un décret en Conseil
+D’État. Lorsque plusieurs administrations sont responsables, le décret détermine les modalités de la
+Coordination entre ces administrations. Il détermine la liste des données de référence et désigne
+Les administrations responsables de leur production et de leur publication. Il fixe la qualité
+Minimale que la publication des données de référence doit respecter, notamment en termes de
+Précision, de degré de détail, de fréquence de mise à jour, d’accessibilité et de format. »
 
-II (nouveau). – Le présent article entre en vigueur à la date de publication du décret mentionné au III de l’article L. 321‑1 du code des relations entre le public et l’administration, et au plus tard six mois après la promulgation de la présente loi.
+II (nouveau). – Le présent article entre en vigueur à la date de publication du décret mentionné
+Au III de l’article L. 321‑1 du code des relations entre le public et l’administration, et au plus
+Tard six mois après la promulgation de la présente loi.
 
-Article 9 bis (nouveau)
+Article 9 bis (nouveau)
 
-Le second alinéa de l’article 13 de la loi n° 86‑1067 du 30 septembre 1986 relative à la liberté de communication est ainsi rédigé :
+Le second alinéa de l’article 13 de la loi n° 86‑1067 du 30 septembre 1986 relative à la liberté
+De communication est ainsi rédigé :
 
-« Les services de radio et de télévision transmettent les données relatives aux temps d’intervention des personnalités politiques dans les journaux et les bulletins d’information, les magazines et les autres émissions des programmes au Conseil supérieur de l’audiovisuel selon les conditions, notamment de périodicité et de format, que le conseil détermine. Le Conseil supérieur de l’audiovisuel communique chaque mois aux présidents de l’Assemblée nationale et du Sénat et aux responsables des différents partis politiques représentés au Parlement le relevé des temps d’intervention des personnalités politiques dans les journaux et les bulletins d’information, les magazines et les autres émissions des programmes. Ce relevé est également publié dans un format ouvert et aisément réutilisable, c’est-à-dire lisible par une machine. »
+« Les services de radio et de télévision transmettent les données relatives aux temps
+D’intervention des personnalités politiques dans les journaux et les bulletins d’information, les
+Magazines et les autres émissions des programmes au Conseil supérieur de l’audiovisuel selon les
+Conditions, notamment de périodicité et de format, que le conseil détermine. Le Conseil supérieur de
+L’audiovisuel communique chaque mois aux présidents de l’Assemblée nationale et du Sénat et aux
+Responsables des différents partis politiques représentés au Parlement le relevé des temps
+D’intervention des personnalités politiques dans les journaux et les bulletins d’information, les
+Magazines et les autres émissions des programmes. Ce relevé est également publié dans un format
+Ouvert et aisément réutilisable, c’est-à-dire lisible par une machine. »
 
-Article 9 ter (nouveau)
+Article 9 ter (nouveau)
 
-Les services de l’État, administrations, établissements publics et entreprises du secteur public, les collectivités territoriales et leurs établissements publics encouragent l’utilisation des logiciels libres et des formats ouverts lors du développement, de l’achat ou de l’utilisation d’un système informatique.
+Les services de l’État, administrations, établissements publics et entreprises du secteur public,
+Les collectivités territoriales et leurs établissements publics encouragent l’utilisation des
+Logiciels libres et des formats ouverts lors du développement, de l’achat ou de l’utilisation d’un
+Système informatique.
 
 Section 2
 
@@ -218,61 +357,116 @@ Données d’intérêt général
 
 Article 10
 
-I. – Après l’article 40‑1 de la loi n° 93‑122 du 29 janvier 1993 relative à la prévention de la corruption et à la transparence de la vie économique et des procédures publiques, il est inséré un article 40‑2 ainsi rédigé :
+I. – Après l’article 40‑1 de la loi n° 93‑122 du 29 janvier 1993 relative à la prévention de la
+Corruption et à la transparence de la vie économique et des procédures publiques, il est inséré un
+Article 40‑2 ainsi rédigé :
 
-« Art. 40‑2. – Le délégataire fournit à la personne publique délégante, dans un standard ouvert aisément réutilisable, c’est-à-dire lisible par une machine, les données et bases de données collectées ou produites à l’occasion de l’exploitation du service public dont il assure la gestion et qui sont indispensables à son exécution. Il autorise par ailleurs la personne publique délégante, ou un tiers désigné par celle‑ci, à extraire et exploiter librement tout ou partie de ces données et bases de données, notamment en vue de leur mise à disposition à titre gratuit à des fins de réutilisation à titre gratuit ou onéreux.
+« Art. 40‑2. – Le délégataire fournit à la personne publique délégante, dans un standard ouvert
+Aisément réutilisable, c’est-à-dire lisible par une machine, les données et bases de données
+Collectées ou produites à l’occasion de l’exploitation du service public dont il assure la gestion
+Et qui sont indispensables à son exécution. Il autorise par ailleurs la personne publique délégante,
+Ou un tiers désigné par celle‑ci, à extraire et exploiter librement tout ou partie de ces données et
+Bases de données, notamment en vue de leur mise à disposition à titre gratuit à des fins de
+Réutilisation à titre gratuit ou onéreux.
 
-« Les données fournies par le délégataire peuvent être publiées, sous réserve des articles L. 311‑5 à L. 311‑7 du code des relations entre le public et l’administration.
+« Les données fournies par le délégataire peuvent être publiées, sous réserve des articles L. 311‑5
+à L. 311‑7 du code des relations entre le public et l’administration.
 
-« La personne publique délégante peut, dans le cahier des charges du contrat ou au cours de l’exécution de ce dernier, exempter le délégataire de tout ou partie des obligations prévues au premier alinéa du présent article par une décision fondée sur des motifs d’intérêt général qu’elle explicite et qui est rendue publique. »
+« La personne publique délégante peut, dans le cahier des charges du contrat ou au cours de
+L’exécution de ce dernier, exempter le délégataire de tout ou partie des obligations prévues au
+Premier alinéa du présent article par une décision fondée sur des motifs d’intérêt général qu’elle
+Explicite et qui est rendue publique. »
 
-II. – Après l’article L. 1411‑3‑1 du code général des collectivités territoriales, il est inséré un article L. 1411‑3‑1 ainsi rédigé :
+II. – Après l’article L. 1411‑3‑1 du code général des collectivités territoriales, il est inséré
+Un article L. 1411‑3‑1 ainsi rédigé :
 
-« Art. L. 1411‑3‑1. – Le délégataire fournit à la personne publique délégante, dans un standard ouvert aisément réutilisable, c’est-à-dire lisible par une machine, les données et bases de données collectées ou produites à l’occasion de l’exploitation du service public dont il assure la gestion et qui sont indispensables à son exécution. Il autorise par ailleurs la personne publique délégante, ou un tiers désigné par celle‑ci, à extraire et exploiter librement tout ou partie de ces données et bases de données, notamment en vue de leur mise à disposition à titre gratuit à des fins de réutilisation à titre gratuit ou onéreux.
+« Art. L. 1411‑3‑1. – Le délégataire fournit à la personne publique délégante, dans un standard
+Ouvert aisément réutilisable, c’est-à-dire lisible par une machine, les données et bases de données
+Collectées ou produites à l’occasion de l’exploitation du service public dont il assure la gestion
+Et qui sont indispensables à son exécution. Il autorise par ailleurs la personne publique délégante,
+Ou un tiers désigné par celle‑ci, à extraire et exploiter librement tout ou partie de ces données et
+Bases de données, notamment en vue de leur mise à disposition à titre gratuit à des fins de
+Réutilisation à titre gratuit ou onéreux.
 
-« Les données fournies par le délégataire peuvent être publiées, sous réserve des articles L. 311‑5 à L. 311‑7 du code des relations entre le public et l’administration.
+« Les données fournies par le délégataire peuvent être publiées, sous réserve des articles L. 311‑5
+à L. 311‑7 du code des relations entre le public et l’administration.
 
-« La personne publique délégante peut, dans le cahier des charges du contrat ou au cours de l’exécution de ce dernier, exempter le délégataire de tout ou partie des obligations prévues au premier alinéa par une décision fondée sur des motifs d’intérêt général qu’elle explicite et qui est rendue publique. »
+« La personne publique délégante peut, dans le cahier des charges du contrat ou au cours de
+L’exécution de ce dernier, exempter le délégataire de tout ou partie des obligations prévues au
+Premier alinéa par une décision fondée sur des motifs d’intérêt général qu’elle explicite et qui est
+Rendue publique. »
 
-III. – Les I et II du présent article sont applicables aux contrats de délégation de service public conclus ou reconduits postérieurement à la promulgation de la présente loi.
+III. – Les I et II du présent article sont applicables aux contrats de délégation de service
+Public conclus ou reconduits postérieurement à la promulgation de la présente loi.
 
-IV (nouveau). – Pour les contrats conclus avant la date d’entrée en vigueur de la présente loi, les personnes publiques peuvent exiger du délégataire la transmission des données et des bases de données à la seule fin de préparer le renouvellement du contrat.
+IV (nouveau). – Pour les contrats conclus avant la date d’entrée en vigueur de la présente loi,
+Les personnes publiques peuvent exiger du délégataire la transmission des données et des bases de
+Données à la seule fin de préparer le renouvellement du contrat.
 
 Article 11
 
-L’article 10 de la loi n° 2000‑321 du 12 avril 2000 relative aux droits des citoyens dans leurs relations avec les administrations est ainsi modifié :
+L’article 10 de la loi n° 2000‑321 du 12 avril 2000 relative aux droits des citoyens dans leurs
+Relations avec les administrations est ainsi modifié :
 
-1° À la première phrase du cinquième alinéa, le mot : « troisième » est remplacé par le mot : « quatrième » ;
+1° À la première phrase du cinquième alinéa, le mot : « troisième » est remplacé par le mot : «
+Quatrième » ;
 
-2° Avant le dernier alinéa, il est inséré un alinéa ainsi rédigé :
+2° Avant le dernier alinéa, il est inséré un alinéa ainsi rédigé :
 
-« L’autorité administrative ou l’organisme chargé de la gestion d’un service public industriel et commercial mentionné au premier alinéa de l’article 9‑1 qui attribue une subvention dépassant le seuil mentionné au quatrième alinéa du présent article rend accessible, sous forme électronique, dans un standard ouvert aisément réutilisable, c’est-à-dire lisible par une machine, les données essentielles de la convention de subvention, dans des conditions fixées par voie réglementaire. »
+« L’autorité administrative ou l’organisme chargé de la gestion d’un service public industriel et
+Commercial mentionné au premier alinéa de l’article 9‑1 qui attribue une subvention dépassant le
+Seuil mentionné au quatrième alinéa du présent article rend accessible, sous forme électronique,
+Dans un standard ouvert aisément réutilisable, c’est-à-dire lisible par une machine, les données
+Essentielles de la convention de subvention, dans des conditions fixées par voie réglementaire. »
 
 Article 12
 
-La loi n° 51‑711 du 7 juin 1951 sur l’obligation, la coordination et le secret en matière de statistiques est ainsi modifiée :
+La loi n° 51‑711 du 7 juin 1951 sur l’obligation, la coordination et le secret en matière de
+Statistiques est ainsi modifiée :
 
-1° Le second alinéa de l’article 3 est supprimé ;
+1° Le second alinéa de l’article 3 est supprimé ;
 
-2° Après le même article, il est inséré un article 3‑1 ainsi rédigé :
+2° Après le même article, il est inséré un article 3‑1 ainsi rédigé :
 
-« Art. 3‑1. – I. – Le ministre chargé de l’économie peut décider, après avis du Conseil national de l’information statistique, que les personnes morales de droit privé sollicitées pour des enquêtes transmettent par voie électronique sécurisée au service statistique public, à des fins exclusives d’établissement de statistiques, les informations présentes dans les bases de données qu’elles détiennent, lorsque ces informations sont recherchées pour les besoins d’enquêtes statistiques qui sont rendues obligatoires en application de l’article 1<sup>er</sup> bis.
+« Art. 3‑1. – I. – Le ministre chargé de l’économie peut décider, après avis du Conseil national de
+L’information statistique, que les personnes morales de droit privé sollicitées pour des enquêtes
+Transmettent par voie électronique sécurisée au service statistique public, à des fins exclusives
+D’établissement de statistiques, les informations présentes dans les bases de données qu’elles
+Détiennent, lorsque ces informations sont recherchées pour les besoins d’enquêtes statistiques qui
+Sont rendues obligatoires en application de l’article 1<sup>er</sup> bis.
 
-« Cette décision est précédée d’une étude de faisabilité et d’opportunité rendue publique.
+« Cette décision est précédée d’une étude de faisabilité et d’opportunité rendue publique.
 
-« Les données transmises par les personnes morales de droit privé sollicitées pour ces enquêtes ne peuvent faire l’objet d’aucune communication de la part du service dépositaire. Seules sont soumises au livre II du code du patrimoine les informations issues de ces données qui ont été agrégées et qui ne permettent pas l’identification de ces personnes morales.
+« Les données transmises par les personnes morales de droit privé sollicitées pour ces enquêtes ne
+Peuvent faire l’objet d’aucune communication de la part du service dépositaire. Seules sont soumises
+Au livre II du code du patrimoine les informations issues de ces données qui ont été agrégées et qui
+Ne permettent pas l’identification de ces personnes morales.
 
-« Les conditions dans lesquelles sont réalisées ces enquêtes, notamment leur faisabilité, leur opportunité, les modalités de collecte des données de même que, le cas échéant, celles de leur enregistrement temporaire et celles de leur destruction font l’objet d’une concertation avec les personnes morales sollicitées pour l’enquête et sont fixées par voie réglementaire.
+« Les conditions dans lesquelles sont réalisées ces enquêtes, notamment leur faisabilité, leur
+Opportunité, les modalités de collecte des données de même que, le cas échéant, celles de leur
+Enregistrement temporaire et celles de leur destruction font l’objet d’une concertation avec les
+Personnes morales sollicitées pour l’enquête et sont fixées par voie réglementaire.
 
-« II. – Par dérogation à l’article 7, en cas de refus de la personne morale sollicitée pour l’enquête de procéder à la transmission d’informations conformément à la décision prise dans les conditions mentionnées au I du présent article, le ministre chargé de l’économie met en demeure la personne enquêtée. Cette mise en demeure fixe le délai imparti à la personne sollicitée pour l’enquête pour faire valoir ses observations. Ce délai ne peut être inférieur à un mois.
+« II. – Par dérogation à l’article 7, en cas de refus de la personne morale sollicitée pour
+L’enquête de procéder à la transmission d’informations conformément à la décision prise dans les
+Conditions mentionnées au I du présent article, le ministre chargé de l’économie met en demeure la
+Personne enquêtée. Cette mise en demeure fixe le délai imparti à la personne sollicitée pour
+L’enquête pour faire valoir ses observations. Ce délai ne peut être inférieur à un mois.
 
-« Si la personne sollicitée pour l’enquête ne se conforme pas à cette mise en demeure, le ministre saisit pour avis le Conseil national de l’information statistique réuni en comité du contentieux des enquêtes statistiques obligatoires. La personne sollicitée pour l’enquête est entendue par le comité.
+« Si la personne sollicitée pour l’enquête ne se conforme pas à cette mise en demeure, le ministre
+Saisit pour avis le Conseil national de l’information statistique réuni en comité du contentieux des
+Enquêtes statistiques obligatoires. La personne sollicitée pour l’enquête est entendue par le
+Comité.
 
-« Au vu de cet avis, le ministre peut, par une décision motivée, prononcer une amende administrative.
+« Au vu de cet avis, le ministre peut, par une décision motivée, prononcer une amende
+Administrative.
 
-« Le montant de la première amende encourue à ce titre ne peut dépasser 25 000 €. En cas de récidive dans un délai de trois ans, le montant de l’amende peut être porté à 50 000 € au plus.
+« Le montant de la première amende encourue à ce titre ne peut dépasser 25 000 €. En cas de
+Récidive dans un délai de trois ans, le montant de l’amende peut être porté à 50 000 € au plus.
 
-« Le ministre peut rendre publiques les sanctions qu’il prononce. Il peut également ordonner leur insertion dans des publications, journaux et supports qu’il désigne aux frais des personnes sanctionnées. »
+« Le ministre peut rendre publiques les sanctions qu’il prononce. Il peut également ordonner leur
+Insertion dans des publications, journaux et supports qu’il désigne aux frais des personnes
+Sanctionnées. »
 
 Section 3
 
@@ -280,50 +474,68 @@ Gouvernance
 
 Article 13
 
-Le I de l’article 13 de la loi n° 78‑17 du 6 janvier 1978 relative à l’informatique, aux fichiers et aux libertés est ainsi modifié :
+Le I de l’article 13 de la loi n° 78‑17 du 6 janvier 1978 relative à l’informatique, aux fichiers
+Et aux libertés est ainsi modifié :
 
-1° Au premier alinéa, le mot : « dix‑sept » est remplacé par le mot : « dix‑huit » ;
+1° Au premier alinéa, le mot : « dix‑sept » est remplacé par le mot : « dix‑huit » ;
 
-1° bis (nouveau) Aux 6° et 7°, les mots : « de l’informatique » sont remplacés par les mots : « du numérique » ;
+1° bis (nouveau) Aux 6° et 7°, les mots : « de l’informatique » sont remplacés par les mots : « du
+Numérique » ;
 
-2° Après le 7°, il est inséré un 8° ainsi rédigé :
+2° Après le 7°, il est inséré un 8° ainsi rédigé :
 
-« 8° Le président de la Commission d’accès aux documents administratifs, ou son représentant. »
+« 8° Le président de la Commission d’accès aux documents administratifs, ou son représentant. »
 
 Article 14
 
-Après l’article 15 de la loi n° 78‑17 du 6 janvier 1978 précitée, il est inséré un article 15 bis ainsi rédigé :
+Après l’article 15 de la loi n° 78‑17 du 6 janvier 1978 précitée, il est inséré un article 15 bis
+Ainsi rédigé :
 
-« Art. 15 bis. – La Commission nationale de l’informatique et des libertés et la Commission d’accès aux documents administratifs se réunissent dans un collège unique, sur l’initiative conjointe de leurs présidents, lorsqu’un sujet d’intérêt commun le justifie. »
+« Art. 15 bis. – La Commission nationale de l’informatique et des libertés et la Commission d’accès
+Aux documents administratifs se réunissent dans un collège unique, sur l’initiative conjointe de
+Leurs présidents, lorsqu’un sujet d’intérêt commun le justifie. »
 
 Article 15
 
-L’article L. 341‑1 du code des relations entre le public et l’administration est ainsi modifié :
+L’article L. 341‑1 du code des relations entre le public et l’administration est ainsi modifié :
 
-1° Le 6° est ainsi rédigé :
+1° Le 6° est ainsi rédigé :
 
-« 6° Le président de la Commission nationale de l’informatique et des libertés, ou son représentant ; »
+« 6° Le président de la Commission nationale de l’informatique et des libertés, ou son représentant
+; »
 
-2° (nouveau) À la deuxième phrase du douzième alinéa, la référence : « et 3° » est remplacée par les références : « , 3° et 6° ».
+2° (nouveau) À la deuxième phrase du douzième alinéa, la référence : « et 3° » est remplacée par
+Les références : « , 3° et 6° ».
 
 Article 16
 
-Après l’article L. 341‑1 du code des relations entre le public et l’administration, il est inséré un article L. 341‑1‑1 ainsi rédigé :
+Après l’article L. 341‑1 du code des relations entre le public et l’administration, il est inséré
+Un article L. 341‑1‑1 ainsi rédigé :
 
-« Art. L. 341‑1‑1. – La Commission d’accès aux documents administratifs et la Commission nationale de l’informatique et des libertés se réunissent dans un collège unique, sur l’initiative conjointe de leurs présidents, lorsqu’un sujet d’intérêt commun le justifie. »
+« Art. L. 341‑1‑1. – La Commission d’accès aux documents administratifs et la Commission nationale
+De l’informatique et des libertés se réunissent dans un collège unique, sur l’initiative conjointe
+De leurs présidents, lorsqu’un sujet d’intérêt commun le justifie. »
 
-Article 16 bis (nouveau)
+Article 16 bis (nouveau)
 
-L’article 18 de la loi n° 78‑753 du 17 juillet 1978 précitée est ainsi modifié :
+L’article 18 de la loi n° 78‑753 du 17 juillet 1978 précitée est ainsi modifié :
 
-1° Après le mot : « mentionnée », la fin du premier alinéa est ainsi rédigée : « au titre IV du livre III du code des relations entre le public et l’administration. » ;
+1° Après le mot : « mentionnée », la fin du premier alinéa est ainsi rédigée : « au titre IV du
+Livre III du code des relations entre le public et l’administration. » ;
 
-2° À la première phrase du cinquième alinéa, la référence : « chapitre III » est remplacée par la référence : « titre IV du livre III du code des relations entre le public et l’administration. » ;
+2° À la première phrase du cinquième alinéa, la référence : « chapitre III » est remplacée par la
+Référence : « titre IV du livre III du code des relations entre le public et l’administration. » ;
 
-3° Il est ajouté un alinéa ainsi rédigé :
+3° Il est ajouté un alinéa ainsi rédigé :
 
-« Pour l’application du présent article, la commission peut être saisie par son président. »
+« Pour l’application du présent article, la commission peut être saisie par son président. »
 
-Article 16 ter (nouveau)
+Article 16 ter (nouveau)
 
-Le Gouvernement remet au Parlement, dans un délai de trois mois à compter de la promulgation de la présente loi, un rapport sur la possibilité de créer un Commissariat à la souveraineté numérique rattaché aux services du Premier ministre dont les missions concourront à l’exercice, dans le cyberespace, de la souveraineté nationale et des droits et libertés individuels et collectifs que la République protège. Ce rapport précise les conditions de mise en place, sous l’égide de ce Commissariat, d’un système d’exploitation souverain et de protocoles de chiffrement des données, ainsi que les moyens et l’organisation nécessaires au fonctionnement de cet établissement public.
+Le Gouvernement remet au Parlement, dans un délai de trois mois à compter de la promulgation de la
+Présente loi, un rapport sur la possibilité de créer un Commissariat à la souveraineté numérique
+Rattaché aux services du Premier ministre dont les missions concourront à l’exercice, dans le
+Cyberespace, de la souveraineté nationale et des droits et libertés individuels et collectifs que la
+République protège. Ce rapport précise les conditions de mise en place, sous l’égide de ce
+Commissariat, d’un système d’exploitation souverain et de protocoles de chiffrement des données,
+Ainsi que les moyens et l’organisation nécessaires au fonctionnement de cet établissement public.

--- a/Titre I/Chapitre Ier - Economie de la donnée.md
+++ b/Titre I/Chapitre Ier - Economie de la donnée.md
@@ -1,16 +1,16 @@
-Titre I<sup>er</sup>
+# Titre I<sup>er</sup>
 
 La circulation des donnÉes et du savoir
 
-Chapitre I<sup>er</sup>
+## Chapitre I<sup>er</sup>
 
 Économie de la donnée
 
-Section 1
+### Section 1
 
 Ouverture de l’accès aux données publiques
 
-Article 1<sup>er</sup>
+#### Article 1<sup>er</sup>
 
 I. – Sous réserve des articles L. 311‑5 et L. 311‑6 du code des relations entre le public et
 L’administration et sans préjudice de l’article L. 114‑8 du même code, les administrations
@@ -40,13 +40,13 @@ VI (nouveau). – Le titre I<sup>er</sup> du livre III du code des relations ent
 L’administration est applicable aux demandes de communication des documents administratifs exercées
 En application du I du présent article.
 
-Article 1<sup>er</sup> bis A (nouveau)
+#### Article 1<sup>er</sup> bis A (nouveau)
 
 Le Gouvernement remet au Parlement, au plus tard le 30 juin 2016, un rapport sur la nécessité de
 Créer une consultation publique en ligne pour tout projet de loi ou proposition de loi avant son
 Inscription à l’ordre du jour du Parlement.
 
-Article 1<sup>er</sup> bis (nouveau)
+#### Article 1<sup>er</sup> bis (nouveau)
 
 I. – À la seconde phrase du premier alinéa de l’article L. 300‑2 du code des relations entre le
 Public et l’administration, après le mot : « prévisions », sont insérés les mots : « , codes sources
@@ -56,7 +56,7 @@ II (nouveau). – À la fin du d du 2° de l’article L. 311‑5 du même code,
 Sécurité des personnes » sont remplacés par les mots : « , à la sécurité des personnes ou à la
 Sécurité des systèmes d’information des administrations ».
 
-Article 1<sup>er</sup> ter (nouveau)
+#### Article 1<sup>er</sup> ter (nouveau)
 
 Le chapitre I<sup>er</sup> du titre I<sup>er</sup> du livre III du code des relations entre le
 Public et l’administration est ainsi modifié :
@@ -68,7 +68,7 @@ S2° L’article L. 311‑9 est complété par un 4° ainsi rédigé :
 
 « 4° Par publication des informations en ligne dans un format ouvert et aisément réutilisable. »
 
-Article 2
+#### Article 2
 
 Après l’article L. 311‑3 du code des relations entre le public et l’administration, il est inséré
 Un article L. 311‑3‑1 ainsi rédigé :
@@ -80,18 +80,18 @@ L’administration à l’intéressé s’il en fait la demande.
 
 « Les conditions d’application du présent article sont fixées par décret en Conseil d’État. »
 
-Article 2 bis (nouveau)
+#### Article 2 bis (nouveau)
 
 Au 1° de l’article L. 311‑5 du code des relations entre le public et l’administration, la première
 Occurrence du mot : « et » est remplacée par les mots : « qui ne portent pas sur un projet de loi ou
 D’ordonnance, les avis ».
 
-Article 3
+#### Article 3
 
 Le deuxième alinéa de l’article L. 312‑1 du code des relations entre le public et l’administration
 Est supprimé.
 
-Article 4
+#### Article 4
 
 I A (nouveau). – Le 1° de l’article L. 311‑6 du code des relations entre le public et
 L’administration est complété par les mots : « , lequel comprend le secret des procédés, des
@@ -153,7 +153,7 @@ Des articles L. 312‑1 à L. 312‑1‑3 du même code.
 III (nouveau). – L’article L. 1112‑23 du code général des collectivités territoriales et l’article
 L. 125‑12 du code des communes de la Nouvelle‑Calédonie sont abrogés.
 
-Article 4 bis (nouveau)
+#### Article 4 bis (nouveau)
 
 Après le 7° du II de l’article L. 541‑10 du code de l’environnement, il est inséré un 8° ainsi
 Rédigé :
@@ -161,7 +161,7 @@ Rédigé :
 « 8° Les conditions dans lesquelles sont encouragées les démarches d’ouverture des données
 Relatives au domaine des déchets ; ».
 
-Article 5
+#### Article 5
 
 I. – À l’article L. 311‑4 du code des relations entre le public et l’administration, après le mot
 : « communiqués », sont insérés les mots : « ou publiés ».
@@ -170,15 +170,15 @@ II. – La publication en ligne prévue à l’article L. 312‑1‑1 du code de
 Et l’administration est effectuée :
 
 1° Six mois après la promulgation de la présente loi, pour les documents mentionnés au 1° du même
-Article L. 312‑1‑1 ;
+#### Article L. 312‑1‑1 ;
 
 2° Un an après la promulgation de la présente loi, pour les documents mentionnés au 2° dudit
-Article L. 312‑1‑1 ;
+#### Article L. 312‑1‑1 ;
 
 3° À une date fixée par décret, et au plus tard deux ans après la promulgation de la présente loi,
 Pour l’ensemble des autres documents entrant dans le champ d’application du même article L. 312‑1‑1.
 
-Article 6
+#### Article 6
 
 I. – L’article 10 de la loi n° 78‑753 du 17 juillet 1978 portant diverses mesures d’amélioration
 Des relations entre l’administration et le public et diverses dispositions d’ordre administratif,
@@ -210,7 +210,7 @@ II (nouveau). – À la seconde phrase du premier alinéa du I de l’article 15
 Référence : « à l’article 1<sup>er</sup> » est remplacée par la référence : « au premier alinéa de
 L’article L. 300‑2 du code des relations entre le public et l’administration ».
 
-Article 6 bis (nouveau)
+#### Article 6 bis (nouveau)
 
 Le premier alinéa de l’article L. 300‑2 du code des relations entre le public et l’administration
 Est complété par une phrase ainsi rédigée :
@@ -218,7 +218,7 @@ Est complété par une phrase ainsi rédigée :
 « Constituent également de tels documents les documents relatifs à la gestion du domaine privé de
 L’État et des collectivités territoriales. »
 
-Article 7
+#### Article 7
 
 La loi n° 78‑753 du 17 juillet 1978 précitée est ainsi modifiée :
 
@@ -244,7 +244,7 @@ Cinq ans, après concertation avec les collectivités territoriales et leurs gro
 Administration souhaite recourir à une licence ne figurant pas sur cette liste, cette licence doit
 être préalablement homologuée par l’État, dans des conditions fixées par décret. »
 
-Article 7 bis (nouveau)
+#### Article 7 bis (nouveau)
 
 I. – L’article 15 de la loi n° 78‑753 du 17 juillet 1978 précitée est complété par un IV ainsi
 Rédigé :
@@ -256,7 +256,7 @@ Redevance. »
 
 II. – Le I du présent article entre en vigueur le 1<sup>er</sup> janvier 2017.
 
-Article 8
+#### Article 8
 
 I. – Le premier alinéa de l’article 17 de la loi n° 78‑753 du 17 juillet 1978 précitée est
 Complété par une phrase ainsi rédigée :
@@ -297,7 +297,7 @@ Le recours dirigé contre le refus de communication ou de publication. » ;
 « Art. L. 342‑6. – Lorsque la commission est consultée sur un projet de loi ou de décret, son avis
 Est rendu public. »
 
-Article 9
+#### Article 9
 
 I. – Au titre II du livre III du code des relations entre le public et l’administration, il est
 Inséré un article L. 321‑1 ainsi rédigé :
@@ -329,7 +329,7 @@ II (nouveau). – Le présent article entre en vigueur à la date de publication
 Au III de l’article L. 321‑1 du code des relations entre le public et l’administration, et au plus
 Tard six mois après la promulgation de la présente loi.
 
-Article 9 bis (nouveau)
+#### Article 9 bis (nouveau)
 
 Le second alinéa de l’article 13 de la loi n° 86‑1067 du 30 septembre 1986 relative à la liberté
 De communication est ainsi rédigé :
@@ -344,22 +344,22 @@ D’intervention des personnalités politiques dans les journaux et les bulletin
 Magazines et les autres émissions des programmes. Ce relevé est également publié dans un format
 Ouvert et aisément réutilisable, c’est-à-dire lisible par une machine. »
 
-Article 9 ter (nouveau)
+#### Article 9 ter (nouveau)
 
 Les services de l’État, administrations, établissements publics et entreprises du secteur public,
 Les collectivités territoriales et leurs établissements publics encouragent l’utilisation des
 Logiciels libres et des formats ouverts lors du développement, de l’achat ou de l’utilisation d’un
 Système informatique.
 
-Section 2
+### Section 2
 
 Données d’intérêt général
 
-Article 10
+#### Article 10
 
 I. – Après l’article 40‑1 de la loi n° 93‑122 du 29 janvier 1993 relative à la prévention de la
 Corruption et à la transparence de la vie économique et des procédures publiques, il est inséré un
-Article 40‑2 ainsi rédigé :
+#### Article 40‑2 ainsi rédigé :
 
 « Art. 40‑2. – Le délégataire fournit à la personne publique délégante, dans un standard ouvert
 Aisément réutilisable, c’est-à-dire lisible par une machine, les données et bases de données
@@ -403,7 +403,7 @@ IV (nouveau). – Pour les contrats conclus avant la date d’entrée en vigueur
 Les personnes publiques peuvent exiger du délégataire la transmission des données et des bases de
 Données à la seule fin de préparer le renouvellement du contrat.
 
-Article 11
+#### Article 11
 
 L’article 10 de la loi n° 2000‑321 du 12 avril 2000 relative aux droits des citoyens dans leurs
 Relations avec les administrations est ainsi modifié :
@@ -419,7 +419,7 @@ Seuil mentionné au quatrième alinéa du présent article rend accessible, sous
 Dans un standard ouvert aisément réutilisable, c’est-à-dire lisible par une machine, les données
 Essentielles de la convention de subvention, dans des conditions fixées par voie réglementaire. »
 
-Article 12
+#### Article 12
 
 La loi n° 51‑711 du 7 juin 1951 sur l’obligation, la coordination et le secret en matière de
 Statistiques est ainsi modifiée :
@@ -468,11 +468,11 @@ Récidive dans un délai de trois ans, le montant de l’amende peut être port�
 Insertion dans des publications, journaux et supports qu’il désigne aux frais des personnes
 Sanctionnées. »
 
-Section 3
+### Section 3
 
 Gouvernance
 
-Article 13
+#### Article 13
 
 Le I de l’article 13 de la loi n° 78‑17 du 6 janvier 1978 relative à l’informatique, aux fichiers
 Et aux libertés est ainsi modifié :
@@ -486,7 +486,7 @@ Numérique » ;
 
 « 8° Le président de la Commission d’accès aux documents administratifs, ou son représentant. »
 
-Article 14
+#### Article 14
 
 Après l’article 15 de la loi n° 78‑17 du 6 janvier 1978 précitée, il est inséré un article 15 bis
 Ainsi rédigé :
@@ -495,7 +495,7 @@ Ainsi rédigé :
 Aux documents administratifs se réunissent dans un collège unique, sur l’initiative conjointe de
 Leurs présidents, lorsqu’un sujet d’intérêt commun le justifie. »
 
-Article 15
+#### Article 15
 
 L’article L. 341‑1 du code des relations entre le public et l’administration est ainsi modifié :
 
@@ -507,7 +507,7 @@ L’article L. 341‑1 du code des relations entre le public et l’administrati
 2° (nouveau) À la deuxième phrase du douzième alinéa, la référence : « et 3° » est remplacée par
 Les références : « , 3° et 6° ».
 
-Article 16
+#### Article 16
 
 Après l’article L. 341‑1 du code des relations entre le public et l’administration, il est inséré
 Un article L. 341‑1‑1 ainsi rédigé :
@@ -516,7 +516,7 @@ Un article L. 341‑1‑1 ainsi rédigé :
 De l’informatique et des libertés se réunissent dans un collège unique, sur l’initiative conjointe
 De leurs présidents, lorsqu’un sujet d’intérêt commun le justifie. »
 
-Article 16 bis (nouveau)
+#### Article 16 bis (nouveau)
 
 L’article 18 de la loi n° 78‑753 du 17 juillet 1978 précitée est ainsi modifié :
 
@@ -530,7 +530,7 @@ Référence : « titre IV du livre III du code des relations entre le public et 
 
 « Pour l’application du présent article, la commission peut être saisie par son président. »
 
-Article 16 ter (nouveau)
+#### Article 16 ter (nouveau)
 
 Le Gouvernement remet au Parlement, dans un délai de trois mois à compter de la promulgation de la
 Présente loi, un rapport sur la possibilité de créer un Commissariat à la souveraineté numérique

--- a/Titre II/Chapitre II - Protection de la vie privée en ligne.md
+++ b/Titre II/Chapitre II - Protection de la vie privée en ligne.md
@@ -8,67 +8,96 @@ Protection des données à caractère personnel
 
 Article 26
 
-L’article 1<sup>er</sup> de la loi n° 78‑17 du 6 janvier 1978 précitée est complété par un alinéa ainsi rédigé :
+L’article 1<sup>er</sup> de la loi n° 78‑17 du 6 janvier 1978 précitée est complété par un alinéa
+Ainsi rédigé :
 
-« Toute personne dispose du droit de décider et de contrôler les usages qui sont faits des données à caractère personnel la concernant, dans les conditions fixées par la présente loi. »
+« Toute personne dispose du droit de décider et de contrôler les usages qui sont faits des données
+à caractère personnel la concernant, dans les conditions fixées par la présente loi. »
 
-Article 26 bis (nouveau)
+Article 26 bis (nouveau)
 
-Le dernier alinéa de l’article 11 de la loi n° 78‑17 du 6 janvier 1978 précitée est complété par les mots : « et comprenant des données sexuées, concernant en particulier la mise en œuvre du II de l’article 40. »
+Le dernier alinéa de l’article 11 de la loi n° 78‑17 du 6 janvier 1978 précitée est complété par
+Les mots : « et comprenant des données sexuées, concernant en particulier la mise en œuvre du II de
+L’article 40. »
 
 Article 26 ter (nouveau)
 
-Au premier alinéa de l’article 31 de la loi n° 78‑17 du 6 janvier 1978 précitée, après le mot : « public », sont insérés les mots : « , dans un format ouvert et aisément réutilisable, ».
+Au premier alinéa de l’article 31 de la loi n° 78‑17 du 6 janvier 1978 précitée, après le mot : «
+Public », sont insérés les mots : « , dans un format ouvert et aisément réutilisable, ».
 
 Article 27
 
-Après le 7° du I de l’article 32 de la loi n° 78‑17 du 6 janvier 1978 précitée, il est inséré un 8° ainsi rédigé :
+Après le 7° du I de l’article 32 de la loi n° 78‑17 du 6 janvier 1978 précitée, il est inséré un
+8° ainsi rédigé :
 
-« 8° De la durée de conservation des catégories de données traitées. »
+« 8° De la durée de conservation des catégories de données traitées. »
 
 Article 28
 
-I. – La section 2 du chapitre V de la loi n° 78‑17 du 6 janvier 1978 précitée est complétée par un article 43‑1 ainsi rédigé :
+I. – La section 2 du chapitre V de la loi n° 78‑17 du 6 janvier 1978 précitée est complétée par un
+Article 43‑1 ainsi rédigé :
 
-« Art. 43‑1. – Sauf dans le cas prévu au 1° du I de l’article 26, lorsque le responsable de traitement a collecté des données à caractère personnel par voie électronique, il permet à toute personne d’exercer par voie électronique les droits prévus au présent chapitre.
+« Art. 43‑1. – Sauf dans le cas prévu au 1° du I de l’article 26, lorsque le responsable de
+Traitement a collecté des données à caractère personnel par voie électronique, il permet à toute
+Personne d’exercer par voie électronique les droits prévus au présent chapitre.
 
-« Lorsque le responsable du traitement est une autorité administrative au sens du I de l’article 1<sup>er</sup> de l’ordonnance n° 2005‑1516 du 8 décembre 2005 relative aux échanges électroniques entre les usagers et les autorités administratives et entre les autorités administratives, le principe énoncé au premier alinéa du présent article est mis en œuvre dans les conditions fixées aux articles L. 112‑7 et suivants du code des relations entre le public et l’administration. »
+« Lorsque le responsable du traitement est une autorité administrative au sens du I de l’article
+1<sup>er</sup> de l’ordonnance n° 2005‑1516 du 8 décembre 2005 relative aux échanges électroniques
+Entre les usagers et les autorités administratives et entre les autorités administratives, le
+Principe énoncé au premier alinéa du présent article est mis en œuvre dans les conditions fixées aux
+Articles L. 112‑7 et suivants du code des relations entre le public et l’administration. »
 
-II. – L’article L. 112‑10 du code des relations entre le public et l’administration est complété par un alinéa ainsi rédigé :
+II. – L’article L. 112‑10 du code des relations entre le public et l’administration est complété
+Par un alinéa ainsi rédigé :
 
-« Le premier alinéa du présent article s’applique lorsque, en application de l’article 43‑1 de la loi n° 78‑17 du 6 janvier 1978 relative à l’informatique, au fichiers et aux libertés, l’autorité administrative doit permettre à toute personne d’exercer par voie électronique les droits prévus au chapitre V de la même loi. »
+« Le premier alinéa du présent article s’applique lorsque, en application de l’article 43‑1 de la
+Loi n° 78‑17 du 6 janvier 1978 relative à l’informatique, au fichiers et aux libertés, l’autorité
+Administrative doit permettre à toute personne d’exercer par voie électronique les droits prévus au
+Chapitre V de la même loi. »
 
 Article 29
 
-Le 4° de l’article 11 de la loi n° 78‑17 du 6 janvier 1978 précitée est ainsi modifié :
+Le 4° de l’article 11 de la loi n° 78‑17 du 6 janvier 1978 précitée est ainsi modifié :
 
-1° Le a est ainsi modifié :
+1° Le a est ainsi modifié :
 
-a) La première phrase est complétée par les mots : « ou sur les dispositions de tout projet de loi ou de décret relatives à la protection des données à caractère personnel ou au traitement de telles données » ;
+A) La première phrase est complétée par les mots : « ou sur les dispositions de tout projet de loi
+Ou de décret relatives à la protection des données à caractère personnel ou au traitement de telles
+Données » ;
 
-b) (nouveau) La seconde phrase est ainsi rédigée :
+B) (nouveau) La seconde phrase est ainsi rédigée :
 
-« L’avis de la commission sur un projet de loi est rendu public. » ;
+« L’avis de la commission sur un projet de loi est rendu public. » ;
 
-c) (nouveau) Est ajoutée une phrase ainsi rédigée :
+C) (nouveau) Est ajoutée une phrase ainsi rédigée :
 
-« Outre les cas prévus aux articles 26 et 27, lorsqu’une loi prévoit qu’un décret ou un arrêté est pris après avis de la commission, cet avis est publié avec le décret ou l’arrêté ; »
+« Outre les cas prévus aux articles 26 et 27, lorsqu’une loi prévoit qu’un décret ou un arrêté est
+Pris après avis de la commission, cet avis est publié avec le décret ou l’arrêté ; »
 
-1° bis (nouveau) Après le a, il est inséré un a bis ainsi rédigé :
+1° bis (nouveau) Après le a, il est inséré un a bis ainsi rédigé :
 
-« a bis) Elle peut être consultée par le président d’une assemblée parlementaire sur une proposition de loi relative à la protection des personnes à l’égard des traitements automatisés ou comportant des dispositions relatives à la protection des données à caractère personnel ou au traitement de telles données, déposée par l’un des membres de cette assemblée, sauf si ce dernier s’y oppose.
+« a bis) Elle peut être consultée par le président d’une assemblée parlementaire sur une
+Proposition de loi relative à la protection des personnes à l’égard des traitements automatisés ou
+Comportant des dispositions relatives à la protection des données à caractère personnel ou au
+Traitement de telles données, déposée par l’un des membres de cette assemblée, sauf si ce dernier
+S’y oppose.
 
-« La commission dispose d’un délai de six semaines à compter de la saisine pour rendre son avis. Ce délai est reconductible une fois par décision du président de la commission.
+« La commission dispose d’un délai de six semaines à compter de la saisine pour rendre son avis. Ce
+Délai est reconductible une fois par décision du président de la commission.
 
-« À défaut de délibération dans les délais, l’avis de la commission est réputé avoir été rendu.
+« À défaut de délibération dans les délais, l’avis de la commission est réputé avoir été rendu.
 
-« L’avis de la commission est adressé au président de l’assemblée qui l’a saisie, qui le communique à l’auteur de la proposition et le rend public ; »
+« L’avis de la commission est adressé au président de l’assemblée qui l’a saisie, qui le communique
+à l’auteur de la proposition et le rend public ; »
 
-2° Après le d, sont insérés des e et f ainsi rédigés :
+2° Après le d, sont insérés des e et f ainsi rédigés :
 
-« e) Elle conduit une réflexion sur les problèmes éthiques et les questions de société soulevés par l’évolution des technologies numériques, en impliquant des personnalités qualifiées et en organisant des débats publics ;
+« e) Elle conduit une réflexion sur les problèmes éthiques et les questions de société soulevés par
+L’évolution des technologies numériques, en impliquant des personnalités qualifiées et en organisant
+Des débats publics ;
 
-« f) Elle promeut, dans le cadre de ses missions, l’utilisation des technologies protectrices de la vie privée, notamment les technologies de chiffrement des données. »
+« f) Elle promeut, dans le cadre de ses missions, l’utilisation des technologies protectrices de la
+Vie privée, notamment les technologies de chiffrement des données. »
 
 Article 29 bis (nouveau)
 
@@ -76,183 +105,300 @@ Article 29 bis (nouveau)
 
 Article 30
 
-La section 1 du chapitre V de la loi n° 78‑17 du 6 janvier 1978 précitée est complétée par un article 37‑1 ainsi rédigé :
+La section 1 du chapitre V de la loi n° 78‑17 du 6 janvier 1978 précitée est complétée par un
+Article 37‑1 ainsi rédigé :
 
-« Art. 37‑1. – La Commission nationale de l’informatique et des libertés peut certifier ou homologuer et publier des référentiels ou des méthodologies générales aux fins de certification de la conformité à la présente loi de processus d’anonymisation des données à caractère personnel, notamment en vue de la réutilisation d’informations publiques mises en ligne dans les conditions prévues au chapitre II du titre I<sup>er</sup> de la loi n° 78‑753 du 17 juillet 1978 portant diverses mesures d’amélioration des relations entre l’administration et le public et diverses dispositions d’ordre administratif, social et fiscal.
+« Art. 37‑1. – La Commission nationale de l’informatique et des libertés peut certifier ou
+Homologuer et publier des référentiels ou des méthodologies générales aux fins de certification de
+La conformité à la présente loi de processus d’anonymisation des données à caractère personnel,
+Notamment en vue de la réutilisation d’informations publiques mises en ligne dans les conditions
+Prévues au chapitre II du titre I<sup>er</sup> de la loi n° 78‑753 du 17 juillet 1978 portant
+Diverses mesures d’amélioration des relations entre l’administration et le public et diverses
+Dispositions d’ordre administratif, social et fiscal.
 
-« Il en est tenu compte, le cas échéant, pour la mise en œuvre des sanctions prévues au chapitre VII de la présente loi. »
+« Il en est tenu compte, le cas échéant, pour la mise en œuvre des sanctions prévues au chapitre
+VII de la présente loi. »
 
 Article 30 bis (nouveau)
 
-I. – L’article L. 135 du code des postes et des communications électroniques est complété par un alinéa ainsi rédigé :
+I. – L’article L. 135 du code des postes et des communications électroniques est complété par un
+Alinéa ainsi rédigé :
 
-« L’Autorité de régulation des communications électroniques et des postes peut saisir pour avis la Commission nationale de l’informatique et des libertés de toute question relevant de la compétence de celle-ci. »
+« L’Autorité de régulation des communications électroniques et des postes peut saisir pour avis la
+Commission nationale de l’informatique et des libertés de toute question relevant de la compétence
+De celle-ci. »
 
-II. – Avant le dernier alinéa de l’article 11 de la loi n° 78-17 du 6 janvier 1978 relative à l’informatique, aux fichiers et aux libertés, il est inséré un alinéa ainsi rédigé :
+II. – Avant le dernier alinéa de l’article 11 de la loi n° 78-17 du 6 janvier 1978 relative à
+L’informatique, aux fichiers et aux libertés, il est inséré un alinéa ainsi rédigé :
 
-« La Commission nationale de l’informatique et des libertés peut saisir pour avis l’Autorité de régulation des communications électroniques et des postes de toute question relevant de la compétence de celle-ci. »
+« La Commission nationale de l’informatique et des libertés peut saisir pour avis l’Autorité de
+Régulation des communications électroniques et des postes de toute question relevant de la
+Compétence de celle-ci. »
 
 Article 31
 
-L’article 36 de la loi n° 78‑17 du 6 janvier 1978 précitée est complété par un alinéa ainsi rédigé :
+L’article 36 de la loi n° 78‑17 du 6 janvier 1978 précitée est complété par un alinéa ainsi rédigé
+:
 
-« – soit en vertu de directives de la personne concernée, dans les conditions définies au III de l’article 40. »
+« – soit en vertu de directives de la personne concernée, dans les conditions définies au III de
+L’article 40. »
 
 Article 32
 
-L’article 40 de la loi n° 78‑17 du 6 janvier 1978 précitée est ainsi modifié :
+L’article 40 de la loi n° 78‑17 du 6 janvier 1978 précitée est ainsi modifié :
 
-1° Au début du premier alinéa, est ajoutée la mention : « I. – » ;
+1° Au début du premier alinéa, est ajoutée la mention : « I. – » ;
 
-2° Après le cinquième alinéa, il est inséré un II ainsi rédigé :
+2° Après le cinquième alinéa, il est inséré un II ainsi rédigé :
 
-« II. – Sur demande de la personne concernée, le responsable du traitement est tenu d’effacer dans les meilleurs délais les données à caractère personnel qui ont été collectées dans le cadre de l’offre de services de la société de l’information lorsque la personne concernée était mineure au moment de la collecte.
+« II. – Sur demande de la personne concernée, le responsable du traitement est tenu d’effacer dans
+Les meilleurs délais les données à caractère personnel qui ont été collectées dans le cadre de
+L’offre de services de la société de l’information lorsque la personne concernée était mineure au
+Moment de la collecte.
 
-« En cas de non‑exécution de l’effacement des données à caractère personnel ou en cas d’absence de réponse du responsable du traitement dans un délai d’un mois après la demande, la personne concernée peut saisir la Commission nationale de l’informatique et des libertés, qui se prononce sur cette demande dans un délai de quinze jours à compter de la date de réception de la réclamation.
+« En cas de non‑exécution de l’effacement des données à caractère personnel ou en cas d’absence de
+Réponse du responsable du traitement dans un délai d’un mois après la demande, la personne concernée
+Peut saisir la Commission nationale de l’informatique et des libertés, qui se prononce sur cette
+Demande dans un délai de quinze jours à compter de la date de réception de la réclamation.
 
-« Les deux premiers alinéas du présent II ne s’appliquent pas lorsque le traitement de données à caractère personnel est nécessaire :
+« Les deux premiers alinéas du présent II ne s’appliquent pas lorsque le traitement de données à
+Caractère personnel est nécessaire :
 
-« 1° Pour exercer le droit à la liberté d’expression et d’information ;
+« 1° Pour exercer le droit à la liberté d’expression et d’information ;
 
-« 2° Pour respecter une obligation légale qui requiert le traitement de ces données ou pour exercer une mission d’intérêt public ou relevant de l’exercice de l’autorité publique dont est investi le responsable du traitement ;
+« 2° Pour respecter une obligation légale qui requiert le traitement de ces données ou pour exercer
+Une mission d’intérêt public ou relevant de l’exercice de l’autorité publique dont est investi le
+Responsable du traitement ;
 
-« 3° Pour des motifs d’intérêt public dans le domaine de la santé publique ;
+« 3° Pour des motifs d’intérêt public dans le domaine de la santé publique ;
 
-« 4° À des fins d’archivage dans l’intérêt public ou à des fins scientifiques, statistiques ou historiques ;
+« 4° À des fins d’archivage dans l’intérêt public ou à des fins scientifiques, statistiques ou
+Historiques ;
 
-« 5° À la constatation, à l’exercice ou à la défense de droits en justice.
+« 5° À la constatation, à l’exercice ou à la défense de droits en justice.
 
-« Les modalités d’application du présent II sont fixées par décret en Conseil d’État. » ;
+« Les modalités d’application du présent II sont fixées par décret en Conseil d’État. » ;
 
-3° (Supprimé)
+3° (Supprimé)
 
-4° Les deux derniers alinéas sont remplacés par un III ainsi rédigé :
+4° Les deux derniers alinéas sont remplacés par un III ainsi rédigé :
 
-« III. – Toute personne peut définir des directives relatives à la conservation, à l’effacement et à la communication de ses données à caractère personnel après son décès. Ces directives sont générales ou particulières.
+« III. – Toute personne peut définir des directives relatives à la conservation, à l’effacement et
+à la communication de ses données à caractère personnel après son décès. Ces directives sont
+Générales ou particulières.
 
-« Les directives générales concernent l’ensemble des données à caractère personnel se rapportant à la personne concernée et peuvent être enregistrées auprès d’un tiers de confiance numérique certifié par la Commission nationale de l’informatique et des libertés.
+« Les directives générales concernent l’ensemble des données à caractère personnel se rapportant à
+La personne concernée et peuvent être enregistrées auprès d’un tiers de confiance numérique certifié
+Par la Commission nationale de l’informatique et des libertés.
 
-« Les directives particulières concernent les traitements de données à caractère personnel visées par ces directives. Elles sont enregistrées auprès des responsables de traitements concernés. Elles font l’objet du consentement spécifique de la personne concernée et ne peuvent résulter de la seule approbation par celle‑ci des conditions générales d’utilisation.
+« Les directives particulières concernent les traitements de données à caractère personnel visées
+Par ces directives. Elles sont enregistrées auprès des responsables de traitements concernés. Elles
+Font l’objet du consentement spécifique de la personne concernée et ne peuvent résulter de la seule
+Approbation par celle‑ci des conditions générales d’utilisation.
 
-« Les directives générales et particulières définissent la manière dont la personne entend que soient exercés, après son décès, les droits mentionnés à la présente section. Le respect de ces directives est sans préjudice des dispositions applicables aux archives publiques comportant des données à caractère personnel.
+« Les directives générales et particulières définissent la manière dont la personne entend que
+Soient exercés, après son décès, les droits mentionnés à la présente section. Le respect de ces
+Directives est sans préjudice des dispositions applicables aux archives publiques comportant des
+Données à caractère personnel.
 
-« Lorsque les directives prévoient la communication de données qui comportent également des données à caractère personnel relatives à des tiers, cette communication s’effectue dans le respect de la présente loi.
+« Lorsque les directives prévoient la communication de données qui comportent également des données
+à caractère personnel relatives à des tiers, cette communication s’effectue dans le respect de la
+Présente loi.
 
-« La personne peut modifier ou révoquer ses directives à tout moment.
+« La personne peut modifier ou révoquer ses directives à tout moment.
 
-« Les directives mentionnées au premier alinéa du présent III peuvent désigner une personne chargée de leur exécution. Celle‑ci a alors qualité, lorsque la personne est décédée, pour prendre connaissance des directives et demander leur mise en œuvre aux responsables de traitements concernés. À défaut de désignation, les personnes suivantes ont qualité, lorsque la personne est décédée, pour prendre connaissance des directives et demander leur mise en œuvre aux responsables de traitements concernés, dans l’ordre suivant :
+« Les directives mentionnées au premier alinéa du présent III peuvent désigner une personne chargée
+De leur exécution. Celle‑ci a alors qualité, lorsque la personne est décédée, pour prendre
+Connaissance des directives et demander leur mise en œuvre aux responsables de traitements
+Concernés. À défaut de désignation, les personnes suivantes ont qualité, lorsque la personne est
+Décédée, pour prendre connaissance des directives et demander leur mise en œuvre aux responsables de
+Traitements concernés, dans l’ordre suivant :
 
-« 1° (nouveau) Les descendants ;
+« 1° (nouveau) Les descendants ;
 
-« 2° Le conjoint non divorcé ;
+« 2° Le conjoint non divorcé ;
 
-« 3° Les héritiers autres que les descendants qui recueillent tout ou partie de la succession ;
+« 3° Les héritiers autres que les descendants qui recueillent tout ou partie de la succession ;
 
-« 4° Les légataires universels ou donataires de l’universalité des biens à venir.
+« 4° Les légataires universels ou donataires de l’universalité des biens à venir.
 
-« En l’absence de directives, les droits mentionnés à la présente section s’éteignent avec le décès de leur titulaire. Toutefois, par dérogation :
+« En l’absence de directives, les droits mentionnés à la présente section s’éteignent avec le décès
+De leur titulaire. Toutefois, par dérogation :
 
-« a) Les héritiers peuvent, lorsque la personne est décédée, avoir accès aux données contenues dans les traitements de données à caractère personnel de la personne lorsque celles-ci sont nécessaires à la liquidation et au partage de la succession.
+« a) Les héritiers peuvent, lorsque la personne est décédée, avoir accès aux données contenues dans
+Les traitements de données à caractère personnel de la personne lorsque celles-ci sont nécessaires à
+La liquidation et au partage de la succession.
 
-« Lorsqu’un notaire a été désigné dans ce cadre, il peut demander l’accès à ces informations s’il joint à sa demande un mandat l’autorisant à agir au nom des ayants droit ;
+« Lorsqu’un notaire a été désigné dans ce cadre, il peut demander l’accès à ces informations s’il
+Joint à sa demande un mandat l’autorisant à agir au nom des ayants droit ;
 
-« b) (nouveau) Les héritiers de la personne décédée justifiant de leur identité peuvent, si des éléments portés à leur connaissance leur laissent présumer que des données à caractère personnel la concernant faisant l’objet d’un traitement n’ont pas été actualisées, exiger du responsable de ce traitement qu’il prenne en considération le décès et procède aux mises à jour qui doivent en être la conséquence ainsi qu’à la clôture du compte.
+« b) (nouveau) Les héritiers de la personne décédée justifiant de leur identité peuvent, si des
+éléments portés à leur connaissance leur laissent présumer que des données à caractère personnel la
+Concernant faisant l’objet d’un traitement n’ont pas été actualisées, exiger du responsable de ce
+Traitement qu’il prenne en considération le décès et procède aux mises à jour qui doivent en être la
+Conséquence ainsi qu’à la clôture du compte.
 
-« Lorsque les héritiers en font la demande, le responsable du traitement doit justifier, sans frais pour le demandeur, qu’il a procédé aux opérations exigées en application du premier alinéa du présent b ».
+« Lorsque les héritiers en font la demande, le responsable du traitement doit justifier, sans frais
+Pour le demandeur, qu’il a procédé aux opérations exigées en application du premier alinéa du
+Présent b ».
 
-« Tout prestataire d’un service de communication au public en ligne informe l’utilisateur du sort des données qui le concernent à son décès et lui permet de choisir de communiquer ou non ses données à un tiers qu’il désigne. »
+« Tout prestataire d’un service de communication au public en ligne informe l’utilisateur du sort
+Des données qui le concernent à son décès et lui permet de choisir de communiquer ou non ses données
+à un tiers qu’il désigne. »
 
 Article 33
 
-I. – L’article 45 de la loi n° 78‑17 du 6 janvier 1978 précitée est ainsi modifié :
+I. – L’article 45 de la loi n° 78‑17 du 6 janvier 1978 précitée est ainsi modifié :
 
-1° Le I est ainsi rédigé :
+1° Le I est ainsi rédigé :
 
-« I. – Lorsque le responsable d’un traitement ne respecte pas les obligations découlant de la présente loi, le président de la Commission nationale de l’informatique et des libertés peut le mettre en demeure de faire cesser le manquement constaté dans un délai qu’il fixe. En cas d’extrême urgence, ce délai peut être ramené à vingt‑quatre heures.
+« I. – Lorsque le responsable d’un traitement ne respecte pas les obligations découlant de la
+Présente loi, le président de la Commission nationale de l’informatique et des libertés peut le
+Mettre en demeure de faire cesser le manquement constaté dans un délai qu’il fixe. En cas d’extrême
+Urgence, ce délai peut être ramené à vingt‑quatre heures.
 
-« Si le responsable du traitement se conforme à la mise en demeure qui lui est adressée, le président de la commission prononce la clôture de la procédure.
+« Si le responsable du traitement se conforme à la mise en demeure qui lui est adressée, le
+Président de la commission prononce la clôture de la procédure.
 
-« Dans le cas contraire, la formation restreinte de la commission peut prononcer, après une procédure contradictoire, les sanctions suivantes :
+« Dans le cas contraire, la formation restreinte de la commission peut prononcer, après une
+Procédure contradictoire, les sanctions suivantes :
 
-« 1° Un avertissement ;
+« 1° Un avertissement ;
 
-« 2° Une sanction pécuniaire, dans les conditions prévues à l’article 47, à l’exception des cas où le traitement est mis en œuvre par l’État ;
+« 2° Une sanction pécuniaire, dans les conditions prévues à l’article 47, à l’exception des cas où
+Le traitement est mis en œuvre par l’État ;
 
-« 3° Une injonction de cesser le traitement, lorsque celui‑ci relève de l’article 22, ou un retrait de l’autorisation accordée en application de l’article 25.
+« 3° Une injonction de cesser le traitement, lorsque celui‑ci relève de l’article 22, ou un retrait
+De l’autorisation accordée en application de l’article 25.
 
-« Lorsque le manquement constaté ne peut faire l’objet d’une mise en conformité dans le cadre d’une mise en demeure, la formation restreinte peut prononcer, sans mise en demeure préalable et après une procédure contradictoire, les sanctions prévues au présent I. » ;
+« Lorsque le manquement constaté ne peut faire l’objet d’une mise en conformité dans le cadre d’une
+Mise en demeure, la formation restreinte peut prononcer, sans mise en demeure préalable et après une
+Procédure contradictoire, les sanctions prévues au présent I. » ;
 
-1° bis (nouveau) Le II est ainsi modifié :
+1° bis (nouveau) Le II est ainsi modifié :
 
-a) À la fin du premier alinéa, les mots : « peut, après une procédure contradictoire, engager une procédure d’urgence, définie par décret en Conseil d’État, pour » sont remplacés par les mots : « , saisie par le président de la commission, peut, dans le cadre d’une procédure d’urgence définie par décret en Conseil d’État, après une procédure contradictoire » ;
+A) À la fin du premier alinéa, les mots : « peut, après une procédure contradictoire, engager une
+Procédure d’urgence, définie par décret en Conseil d’État, pour » sont remplacés par les mots : « ,
+Saisie par le président de la commission, peut, dans le cadre d’une procédure d’urgence définie par
+Décret en Conseil d’État, après une procédure contradictoire » ;
 
-b) Au 2°, la référence : « premier alinéa » est remplacée par la référence : « 1° » ;
+B) Au 2°, la référence : « premier alinéa » est remplacée par la référence : « 1° » ;
 
-2° Au III, les mots : « de sécurité » sont supprimés.
+2° Au III, les mots : « de sécurité » sont supprimés.
 
-II. – Après la première phrase du deuxième alinéa de l’article 46 de la même loi, est insérée une phrase ainsi rédigée :
+II. – Après la première phrase du deuxième alinéa de l’article 46 de la même loi, est insérée une
+Phrase ainsi rédigée :
 
-« Elle peut ordonner que les personnes sanctionnées informent individuellement de cette sanction, à leur frais, chacune des personnes concernées. »
+« Elle peut ordonner que les personnes sanctionnées informent individuellement de cette sanction, à
+Leur frais, chacune des personnes concernées. »
 
-III (nouveau). – Au second alinéa de l’article 226‑16 du code pénal, la référence : « 2° » est remplacée par la référence : « 3° ».
+III (nouveau). – Au second alinéa de l’article 226‑16 du code pénal, la référence : « 2° » est
+Remplacée par la référence : « 3° ».
 
 Article 33 bis A (nouveau)
 
-La section 2 du chapitre V de la loi n° 78‑17 du 6 janvier 1978 précitée est complétée par un article 43‑2 ainsi rédigé :
+La section 2 du chapitre V de la loi n° 78‑17 du 6 janvier 1978 précitée est complétée par un
+Article 43‑2 ainsi rédigé :
 
-« Art. 43‑2. – Les personnes suivantes peuvent exercer devant une juridiction civile une action collective de protection des données personnelles afin d’obtenir la cessation d’une violation de la présente loi :
+« Art. 43‑2. – Les personnes suivantes peuvent exercer devant une juridiction civile une action
+Collective de protection des données personnelles afin d’obtenir la cessation d’une violation de la
+Présente loi :
 
-« 1° Les associations ayant pour objet la protection de la vie privée et des données personnelles ;
+« 1° Les associations ayant pour objet la protection de la vie privée et des données personnelles ;
 
-« 2° Les associations de défense des consommateurs représentatives au niveau national et agréées en application de l’article L. 411‑1 du code de la consommation, lorsque le traitement de données personnelles affecte des consommateurs ;
+« 2° Les associations de défense des consommateurs représentatives au niveau national et agréées en
+Application de l’article L. 411‑1 du code de la consommation, lorsque le traitement de données
+Personnelles affecte des consommateurs ;
 
-« 3° Les organisations syndicales de salariés, lorsque le traitement affecte des salariés ;
+« 3° Les organisations syndicales de salariés, lorsque le traitement affecte des salariés ;
 
-« 4° Toute association formée aux seules fins d’entreprendre l’action collective concernée.
+« 4° Toute association formée aux seules fins d’entreprendre l’action collective concernée.
 
-« L’exercice de l’action est subordonné à l’accomplissement de démarches préalables auprès du responsable de traitement afin qu’il fasse cesser la violation. »
+« L’exercice de l’action est subordonné à l’accomplissement de démarches préalables auprès du
+Responsable de traitement afin qu’il fasse cesser la violation. »
 
 Article 33 bis B (nouveau)
 
-Les deux premiers alinéas de l’article 47 de la loi n° 78‑17 du 6 janvier 1978 précitée sont ainsi rédigés :
+Les deux premiers alinéas de l’article 47 de la loi n° 78‑17 du 6 janvier 1978 précitée sont ainsi
+Rédigés :
 
-« Le montant de la sanction pécuniaire prévue au I de l’article 45 est proportionné à la gravité du manquement commis et aux avantages tirés de ce manquement. La formation restreinte de la Commission nationale de l’informatique et des libertés prend notamment en compte le caractère intentionnel ou de négligence du manquement, les mesures prises par le responsable du traitement pour atténuer les dommages subis par les personnes concernées, le degré de coopération avec la commission afin de remédier au manquement et d’atténuer ses effets négatifs éventuels, les catégories de données à caractère personnel concernées et la manière dont le manquement a été porté à la connaissance de la Commission.
+« Le montant de la sanction pécuniaire prévue au I de l’article 45 est proportionné à la gravité du
+Manquement commis et aux avantages tirés de ce manquement. La formation restreinte de la Commission
+Nationale de l’informatique et des libertés prend notamment en compte le caractère intentionnel ou
+De négligence du manquement, les mesures prises par le responsable du traitement pour atténuer les
+Dommages subis par les personnes concernées, le degré de coopération avec la commission afin de
+Remédier au manquement et d’atténuer ses effets négatifs éventuels, les catégories de données à
+Caractère personnel concernées et la manière dont le manquement a été porté à la connaissance de la
+Commission.
 
-« Le montant de la sanction ne peut excéder 20 millions d’euros ou, dans le cas d’une entreprise, 4 % du chiffre d’affaires annuel total au niveau mondial réalisé lors de l’exercice précédant l’exercice au cours duquel le manquement a été commis, si ce montant est plus élevé. Toutefois, pour la méconnaissance du chapitre IV ainsi que des articles 34 à 35 de la présente loi, le montant maximal est de 10 millions d’euros ou, s’agissant d’une entreprise, de 2 % du chiffre d’affaires annuel total au niveau mondial réalisé lors de l’exercice précédant l’exercice au cours duquel le manquement a été commis, si ce montant est plus élevé. »
+« Le montant de la sanction ne peut excéder 20 millions d’euros ou, dans le cas d’une entreprise, 4
+% du chiffre d’affaires annuel total au niveau mondial réalisé lors de l’exercice précédant
+L’exercice au cours duquel le manquement a été commis, si ce montant est plus élevé. Toutefois, pour
+La méconnaissance du chapitre IV ainsi que des articles 34 à 35 de la présente loi, le montant
+Maximal est de 10 millions d’euros ou, s’agissant d’une entreprise, de 2 % du chiffre d’affaires
+Annuel total au niveau mondial réalisé lors de l’exercice précédant l’exercice au cours duquel le
+Manquement a été commis, si ce montant est plus élevé. »
 
-Article 33 bis (nouveau)
+Article 33 bis (nouveau)
 
-Le chapitre VII de la loi n° 78‑17 du 6 janvier 1978 précitée est complété par un article 49 bis ainsi rédigé :
+Le chapitre VII de la loi n° 78‑17 du 6 janvier 1978 précitée est complété par un article 49 bis
+Ainsi rédigé :
 
-« Art. 49 bis. – La Commission nationale de l’informatique et des libertés peut, à la demande d’une autorité exerçant des compétences analogues aux siennes dans un autre État non membre de l’Union européenne, dès lors qu’il offre un niveau de protection adéquat des données à caractère personnel, procéder à des vérifications dans les mêmes conditions que celles prévues à l’article 44, sauf s’il s’agit d’un traitement mentionné aux I ou II de l’article 26.
+« Art. 49 bis. – La Commission nationale de l’informatique et des libertés peut, à la demande d’une
+Autorité exerçant des compétences analogues aux siennes dans un autre État non membre de l’Union
+Européenne, dès lors qu’il offre un niveau de protection adéquat des données à caractère personnel,
+Procéder à des vérifications dans les mêmes conditions que celles prévues à l’article 44, sauf s’il
+S’agit d’un traitement mentionné aux I ou II de l’article 26.
 
-« Le président de la commission ou la formation restreinte peuvent, à la demande d’une autorité exerçant des compétences analogues aux leurs dans un autre État non membre de l’Union européenne, dès lors que celui-ci offre un niveau de protection adéquat des données à caractère personnel, prendre les mesures mentionnées aux articles 45 à 47, dans les conditions prévues aux mêmes articles, sauf s’il s’agit d’un traitement mentionné aux I ou II de l’article 26.
+« Le président de la commission ou la formation restreinte peuvent, à la demande d’une autorité
+Exerçant des compétences analogues aux leurs dans un autre État non membre de l’Union européenne,
+Dès lors que celui-ci offre un niveau de protection adéquat des données à caractère personnel,
+Prendre les mesures mentionnées aux articles 45 à 47, dans les conditions prévues aux mêmes
+Articles, sauf s’il s’agit d’un traitement mentionné aux I ou II de l’article 26.
 
-« La commission est habilitée à communiquer les informations qu’elle recueille ou qu’elle détient, à leur demande, aux autorités exerçant des compétences analogues aux siennes dans d’autres États non membres de l’Union européenne, dès lors qu’ils offrent un niveau de protection adéquat des données à caractère personnel. 
+« La commission est habilitée à communiquer les informations qu’elle recueille ou qu’elle détient,
+à leur demande, aux autorités exerçant des compétences analogues aux siennes dans d’autres États non
+Membres de l’Union européenne, dès lors qu’ils offrent un niveau de protection adéquat des données à
+Caractère personnel.
 
-« La commission, pour la mise en œuvre du présent article, conclut préalablement une convention organisant ses relations avec l’autorité exerçant des compétences analogues aux siennes. Cette convention est publiée au Journal officiel. »
+« La commission, pour la mise en œuvre du présent article, conclut préalablement une convention
+Organisant ses relations avec l’autorité exerçant des compétences analogues aux siennes. Cette
+Convention est publiée au Journal officiel. »
 
 Article 33 ter A (nouveau)
 
-La section 1 du chapitre IV du titre I<sup>er</sup> du livre II du code des postes et des communications électroniques est complétée par un article L. 36‑14 ainsi rédigé :
+La section 1 du chapitre IV du titre I<sup>er</sup> du livre II du code des postes et des
+Communications électroniques est complétée par un article L. 36‑14 ainsi rédigé :
 
-« Art. L. 36‑14. – Dans l’exercice de leurs missions, les fonctionnaires et agents de l’Autorité de régulation des communications électroniques et des postes sont habilités à constater les infractions et manquements à la loi n° 78‑17 du 6 janvier 1978 relative à l’informatique, aux fichiers et aux libertés et peuvent communiquer ces constatations à la Commission nationale de l’informatique et des libertés. »
+« Art. L. 36‑14. – Dans l’exercice de leurs missions, les fonctionnaires et agents de l’Autorité de
+Régulation des communications électroniques et des postes sont habilités à constater les infractions
+Et manquements à la loi n° 78‑17 du 6 janvier 1978 relative à l’informatique, aux fichiers et aux
+Libertés et peuvent communiquer ces constatations à la Commission nationale de l’informatique et des
+Libertés. »
 
 Article 33 ter (nouveau)
 
-Après l’article 2‑23 du code de procédure pénale, il est inséré un article 2‑24 ainsi rédigé :
+Après l’article 2‑23 du code de procédure pénale, il est inséré un article 2‑24 ainsi rédigé :
 
-« Art. 2‑24. – Toute association régulièrement déclarée depuis au moins deux ans à la date des faits et se proposant, par ses statuts, de protéger les données personnelles ou la vie privée peut exercer les droits reconnus à la partie civile en ce qui concerne les infractions prévues aux articles 226‑16 à 226-24 du code pénal. Toutefois, quand l’infraction a été commise envers des personnes considérées individuellement, l’association n’est recevable dans son action que si elle justifie avoir reçu l’accord de ces personnes. »
+« Art. 2‑24. – Toute association régulièrement déclarée depuis au moins deux ans à la date des
+Faits et se proposant, par ses statuts, de protéger les données personnelles ou la vie privée peut
+Exercer les droits reconnus à la partie civile en ce qui concerne les infractions prévues aux
+Articles 226‑16 à 226-24 du code pénal. Toutefois, quand l’infraction a été commise envers des
+Personnes considérées individuellement, l’association n’est recevable dans son action que si elle
+Justifie avoir reçu l’accord de ces personnes. »
 
 Article 33 quater (nouveau)
 
-L’article 226‑1 du code pénal est ainsi modifié :
+L’article 226‑1 du code pénal est ainsi modifié :
 
-1° Au dernier alinéa, les mots : « au présent article » sont remplacés par les références : « aux 1° et 2° » ;
+1° Au dernier alinéa, les mots : « au présent article » sont remplacés par les références : « aux
+1° et 2° » ;
 
-2° Il est ajouté un alinéa ainsi rédigé :
+2° Il est ajouté un alinéa ainsi rédigé :
 
-« Est puni de deux ans d’emprisonnement et de 60 000 € d’amende le fait de transmettre ou de diffuser sans le consentement exprès de la personne l’image ou la voix de celle-ci, prise dans un lieu public ou privé, dès lors qu’elle présente un caractère sexuel. »
+« Est puni de deux ans d’emprisonnement et de 60 000 € d’amende le fait de transmettre ou de
+Diffuser sans le consentement exprès de la personne l’image ou la voix de celle-ci, prise dans un
+Lieu public ou privé, dès lors qu’elle présente un caractère sexuel. »
 
 Section 2
 
@@ -260,13 +406,25 @@ Confidentialité des correspondances électroniques privées
 
 Article 34
 
-L’article L. 32‑3 du code des postes et des communications électroniques est ainsi rédigé:
+L’article L. 32‑3 du code des postes et des communications électroniques est ainsi rédigé:
 
-« Art. L. 32‑3. – I. – Les opérateurs, ainsi que les membres de leur personnel, sont tenus de respecter le secret des correspondances. Le secret couvre le contenu de la correspondance, l’identité des correspondants ainsi que, le cas échéant, l’intitulé du message et les documents joints à la correspondance.
+« Art. L. 32‑3. – I. – Les opérateurs, ainsi que les membres de leur personnel, sont tenus de
+Respecter le secret des correspondances. Le secret couvre le contenu de la correspondance,
+L’identité des correspondants ainsi que, le cas échéant, l’intitulé du message et les documents
+Joints à la correspondance.
 
-« Les personnes qui éditent un service de communication au public en ligne, au sens du deuxième alinéa du II de l’article 6 de la loi n° 2004‑575 du 21 juin 2004 pour la confiance dans l’économie numérique, permettant à leurs utilisateurs d’échanger des correspondances, ainsi que les membres de leur personnel, respectent le secret de celles‑ci. Le secret couvre le contenu de la correspondance, l’identité des correspondants ainsi que, le cas échéant, l’intitulé du message et les documents joints à la correspondance.
+« Les personnes qui éditent un service de communication au public en ligne, au sens du deuxième
+Alinéa du II de l’article 6 de la loi n° 2004‑575 du 21 juin 2004 pour la confiance dans l’économie
+Numérique, permettant à leurs utilisateurs d’échanger des correspondances, ainsi que les membres de
+Leur personnel, respectent le secret de celles‑ci. Le secret couvre le contenu de la correspondance,
+L’identité des correspondants ainsi que, le cas échéant, l’intitulé du message et les documents
+Joints à la correspondance.
 
-« II bis (nouveau). – Le traitement automatisé d’analyse, à des fins publicitaires ou statistiques, du contenu de la correspondance en ligne, de l’intitulé ou des documents mentionnés aux I et II est interdit, sauf si le consentement exprès de l’utilisateur est recueilli à une périodicité fixée par voie réglementaire, qui ne peut être supérieure à un an.
+« II bis (nouveau). – Le traitement automatisé d’analyse, à des fins publicitaires ou statistiques,
+Du contenu de la correspondance en ligne, de l’intitulé ou des documents mentionnés aux I et II est
+Interdit, sauf si le consentement exprès de l’utilisateur est recueilli à une périodicité fixée par
+Voie réglementaire, qui ne peut être supérieure à un an.
 
-« III. – Les opérateurs et les personnes mentionnés aux I et II sont tenus de porter à la connaissance de leur personnel les obligations résultant du présent article. »
+« III. – Les opérateurs et les personnes mentionnés aux I et II sont tenus de porter à la
+Connaissance de leur personnel les obligations résultant du présent article. »
 

--- a/Titre II/Chapitre II - Protection de la vie privée en ligne.md
+++ b/Titre II/Chapitre II - Protection de la vie privée en ligne.md
@@ -1,12 +1,12 @@
-Chapitre II
+## Chapitre II
 
 Protection de la vie privée en ligne
 
-Section 1
+### Section 1
 
 Protection des données à caractère personnel
 
-Article 26
+#### Article 26
 
 L’article 1<sup>er</sup> de la loi n° 78‑17 du 6 janvier 1978 précitée est complété par un alinéa
 Ainsi rédigé :
@@ -14,28 +14,28 @@ Ainsi rédigé :
 « Toute personne dispose du droit de décider et de contrôler les usages qui sont faits des données
 à caractère personnel la concernant, dans les conditions fixées par la présente loi. »
 
-Article 26 bis (nouveau)
+#### Article 26 bis (nouveau)
 
 Le dernier alinéa de l’article 11 de la loi n° 78‑17 du 6 janvier 1978 précitée est complété par
 Les mots : « et comprenant des données sexuées, concernant en particulier la mise en œuvre du II de
 L’article 40. »
 
-Article 26 ter (nouveau)
+#### Article 26 ter (nouveau)
 
 Au premier alinéa de l’article 31 de la loi n° 78‑17 du 6 janvier 1978 précitée, après le mot : «
 Public », sont insérés les mots : « , dans un format ouvert et aisément réutilisable, ».
 
-Article 27
+#### Article 27
 
 Après le 7° du I de l’article 32 de la loi n° 78‑17 du 6 janvier 1978 précitée, il est inséré un
 8° ainsi rédigé :
 
 « 8° De la durée de conservation des catégories de données traitées. »
 
-Article 28
+#### Article 28
 
 I. – La section 2 du chapitre V de la loi n° 78‑17 du 6 janvier 1978 précitée est complétée par un
-Article 43‑1 ainsi rédigé :
+#### Article 43‑1 ainsi rédigé :
 
 « Art. 43‑1. – Sauf dans le cas prévu au 1° du I de l’article 26, lorsque le responsable de
 Traitement a collecté des données à caractère personnel par voie électronique, il permet à toute
@@ -45,7 +45,7 @@ Personne d’exercer par voie électronique les droits prévus au présent chapi
 1<sup>er</sup> de l’ordonnance n° 2005‑1516 du 8 décembre 2005 relative aux échanges électroniques
 Entre les usagers et les autorités administratives et entre les autorités administratives, le
 Principe énoncé au premier alinéa du présent article est mis en œuvre dans les conditions fixées aux
-Articles L. 112‑7 et suivants du code des relations entre le public et l’administration. »
+#### Articles L. 112‑7 et suivants du code des relations entre le public et l’administration. »
 
 II. – L’article L. 112‑10 du code des relations entre le public et l’administration est complété
 Par un alinéa ainsi rédigé :
@@ -53,9 +53,9 @@ Par un alinéa ainsi rédigé :
 « Le premier alinéa du présent article s’applique lorsque, en application de l’article 43‑1 de la
 Loi n° 78‑17 du 6 janvier 1978 relative à l’informatique, au fichiers et aux libertés, l’autorité
 Administrative doit permettre à toute personne d’exercer par voie électronique les droits prévus au
-Chapitre V de la même loi. »
+## Chapitre V de la même loi. »
 
-Article 29
+#### Article 29
 
 Le 4° de l’article 11 de la loi n° 78‑17 du 6 janvier 1978 précitée est ainsi modifié :
 
@@ -99,14 +99,14 @@ Des débats publics ;
 « f) Elle promeut, dans le cadre de ses missions, l’utilisation des technologies protectrices de la
 Vie privée, notamment les technologies de chiffrement des données. »
 
-Article 29 bis (nouveau)
+#### Article 29 bis (nouveau)
 
 (Supprimé)
 
-Article 30
+#### Article 30
 
 La section 1 du chapitre V de la loi n° 78‑17 du 6 janvier 1978 précitée est complétée par un
-Article 37‑1 ainsi rédigé :
+#### Article 37‑1 ainsi rédigé :
 
 « Art. 37‑1. – La Commission nationale de l’informatique et des libertés peut certifier ou
 Homologuer et publier des référentiels ou des méthodologies générales aux fins de certification de
@@ -119,7 +119,7 @@ Dispositions d’ordre administratif, social et fiscal.
 « Il en est tenu compte, le cas échéant, pour la mise en œuvre des sanctions prévues au chapitre
 VII de la présente loi. »
 
-Article 30 bis (nouveau)
+#### Article 30 bis (nouveau)
 
 I. – L’article L. 135 du code des postes et des communications électroniques est complété par un
 Alinéa ainsi rédigé :
@@ -135,7 +135,7 @@ L’informatique, aux fichiers et aux libertés, il est inséré un alinéa ains
 Régulation des communications électroniques et des postes de toute question relevant de la
 Compétence de celle-ci. »
 
-Article 31
+#### Article 31
 
 L’article 36 de la loi n° 78‑17 du 6 janvier 1978 précitée est complété par un alinéa ainsi rédigé
 :
@@ -143,7 +143,7 @@ L’article 36 de la loi n° 78‑17 du 6 janvier 1978 précitée est complété
 « – soit en vertu de directives de la personne concernée, dans les conditions définies au III de
 L’article 40. »
 
-Article 32
+#### Article 32
 
 L’article 40 de la loi n° 78‑17 du 6 janvier 1978 précitée est ainsi modifié :
 
@@ -246,7 +246,7 @@ Présent b ».
 Des données qui le concernent à son décès et lui permet de choisir de communiquer ou non ses données
 à un tiers qu’il désigne. »
 
-Article 33
+#### Article 33
 
 I. – L’article 45 de la loi n° 78‑17 du 6 janvier 1978 précitée est ainsi modifié :
 
@@ -295,10 +295,10 @@ Leur frais, chacune des personnes concernées. »
 III (nouveau). – Au second alinéa de l’article 226‑16 du code pénal, la référence : « 2° » est
 Remplacée par la référence : « 3° ».
 
-Article 33 bis A (nouveau)
+#### Article 33 bis A (nouveau)
 
 La section 2 du chapitre V de la loi n° 78‑17 du 6 janvier 1978 précitée est complétée par un
-Article 43‑2 ainsi rédigé :
+#### Article 43‑2 ainsi rédigé :
 
 « Art. 43‑2. – Les personnes suivantes peuvent exercer devant une juridiction civile une action
 Collective de protection des données personnelles afin d’obtenir la cessation d’une violation de la
@@ -317,7 +317,7 @@ Personnelles affecte des consommateurs ;
 « L’exercice de l’action est subordonné à l’accomplissement de démarches préalables auprès du
 Responsable de traitement afin qu’il fasse cesser la violation. »
 
-Article 33 bis B (nouveau)
+#### Article 33 bis B (nouveau)
 
 Les deux premiers alinéas de l’article 47 de la loi n° 78‑17 du 6 janvier 1978 précitée sont ainsi
 Rédigés :
@@ -339,7 +339,7 @@ Maximal est de 10 millions d’euros ou, s’agissant d’une entreprise, de 2 %
 Annuel total au niveau mondial réalisé lors de l’exercice précédant l’exercice au cours duquel le
 Manquement a été commis, si ce montant est plus élevé. »
 
-Article 33 bis (nouveau)
+#### Article 33 bis (nouveau)
 
 Le chapitre VII de la loi n° 78‑17 du 6 janvier 1978 précitée est complété par un article 49 bis
 Ainsi rédigé :
@@ -354,7 +354,7 @@ S’agit d’un traitement mentionné aux I ou II de l’article 26.
 Exerçant des compétences analogues aux leurs dans un autre État non membre de l’Union européenne,
 Dès lors que celui-ci offre un niveau de protection adéquat des données à caractère personnel,
 Prendre les mesures mentionnées aux articles 45 à 47, dans les conditions prévues aux mêmes
-Articles, sauf s’il s’agit d’un traitement mentionné aux I ou II de l’article 26.
+#### Articles, sauf s’il s’agit d’un traitement mentionné aux I ou II de l’article 26.
 
 « La commission est habilitée à communiquer les informations qu’elle recueille ou qu’elle détient,
 à leur demande, aux autorités exerçant des compétences analogues aux siennes dans d’autres États non
@@ -365,7 +365,7 @@ Caractère personnel.
 Organisant ses relations avec l’autorité exerçant des compétences analogues aux siennes. Cette
 Convention est publiée au Journal officiel. »
 
-Article 33 ter A (nouveau)
+#### Article 33 ter A (nouveau)
 
 La section 1 du chapitre IV du titre I<sup>er</sup> du livre II du code des postes et des
 Communications électroniques est complétée par un article L. 36‑14 ainsi rédigé :
@@ -376,18 +376,18 @@ Et manquements à la loi n° 78‑17 du 6 janvier 1978 relative à l’informati
 Libertés et peuvent communiquer ces constatations à la Commission nationale de l’informatique et des
 Libertés. »
 
-Article 33 ter (nouveau)
+#### Article 33 ter (nouveau)
 
 Après l’article 2‑23 du code de procédure pénale, il est inséré un article 2‑24 ainsi rédigé :
 
 « Art. 2‑24. – Toute association régulièrement déclarée depuis au moins deux ans à la date des
 Faits et se proposant, par ses statuts, de protéger les données personnelles ou la vie privée peut
 Exercer les droits reconnus à la partie civile en ce qui concerne les infractions prévues aux
-Articles 226‑16 à 226-24 du code pénal. Toutefois, quand l’infraction a été commise envers des
+#### Articles 226‑16 à 226-24 du code pénal. Toutefois, quand l’infraction a été commise envers des
 Personnes considérées individuellement, l’association n’est recevable dans son action que si elle
 Justifie avoir reçu l’accord de ces personnes. »
 
-Article 33 quater (nouveau)
+#### Article 33 quater (nouveau)
 
 L’article 226‑1 du code pénal est ainsi modifié :
 
@@ -400,11 +400,11 @@ L’article 226‑1 du code pénal est ainsi modifié :
 Diffuser sans le consentement exprès de la personne l’image ou la voix de celle-ci, prise dans un
 Lieu public ou privé, dès lors qu’elle présente un caractère sexuel. »
 
-Section 2
+### Section 2
 
 Confidentialité des correspondances électroniques privées
 
-Article 34
+#### Article 34
 
 L’article L. 32‑3 du code des postes et des communications électroniques est ainsi rédigé:
 

--- a/Titre II/Chapitre Ier - Environnement ouvert.md
+++ b/Titre II/Chapitre Ier - Environnement ouvert.md
@@ -3,15 +3,15 @@ TITRE II
 La protection DES DROITS
 Dans la société numérique
 
-Chapitre I<sup>er</sup>
+## Chapitre I<sup>er</sup>
 
 Environnement ouvert
 
-Section 1
+### Section 1
 
 Neutralité de l’internet
 
-Article 19
+#### Article 19
 
 Le titre I<sup>er</sup> du livre II du code des postes et des communications électroniques est
 Ainsi modifié :
@@ -85,7 +85,7 @@ E) À la première phrase du II, les mots : « ou un fournisseur de services de 
 électroniques » sont remplacés par les mots : « , un fournisseur de services de communications
 électroniques ou un fournisseur de services de communication au public en ligne ».
 
-Article 19 bis (nouveau)
+#### Article 19 bis (nouveau)
 
 Le chapitre III du titre I<sup>er</sup> du livre I<sup>er</sup> de la première partie du code de
 La propriété intellectuelle est complété par un article L. 113‑11 ainsi rédigé :
@@ -96,7 +96,7 @@ Domaine public ou de promouvoir la diffusion des savoirs peut exercer les droits
 Partie civile et saisir le tribunal de grande instance afin de faire cesser tout obstacle à la libre
 Réutilisation d’une œuvre entrée dans le domaine public. »
 
-Article 20
+#### Article 20
 
 L’article L. 33‑1 du code des postes et des communications électroniques est complété par un VI
 Ainsi rédigé :
@@ -110,13 +110,13 @@ Connecté à internet, par l’intermédiaire du service d’accès auquel il a 
 
 « 2° Ou de donner à des tiers accès à ces données. »
 
-Article 20 bis A (nouveau)
+#### Article 20 bis A (nouveau)
 
 À compter du 1<sup>er</sup> janvier 2018, tout équipement terminal, au sens de l’article L. 32 du
 Code des postes et des communications électroniques, destiné à la vente ou la location sur le
 Territoire français est compatible avec la norme IPV6.
 
-Article 20 bis (nouveau)
+#### Article 20 bis (nouveau)
 
 Le code des postes et des communications électroniques est ainsi modifié :
 
@@ -225,13 +225,13 @@ C) Le IV est ainsi modifié :
 Sous scellés. L’occupant des lieux ou son représentant est avisé qu’il peut assister à l’ouverture
 Des scellés ; l’inventaire est alors établi. »
 
-Article 20 ter (nouveau)
+#### Article 20 ter (nouveau)
 
 À la première phrase du deuxième alinéa de l’article L. 125 du code des postes et des
 Communications électroniques, après la deuxième occurrence du mot : « et », sont insérés les mots :
 « étudie les questions relatives à la neutralité de l’internet. Elle ».
 
-Article 20 quater (nouveau)
+#### Article 20 quater (nouveau)
 
 I. – Aux premier et troisième alinéas de l’article L. 2, au II de l’article L. 2‑2, à la première
 Phrase du premier alinéa de l’article L. 33‑2, à la dernière phrase de l’avant-dernier alinéa de
@@ -250,7 +250,7 @@ Service public de la poste et à France Télécom, les mots : « supérieure du 
 Et des communications électroniques » sont remplacés par les mots : « parlementaire du numérique et
 Des postes ».
 
-Article 20 quinquies (nouveau)
+#### Article 20 quinquies (nouveau)
 
 L’article L. 130 du code des postes et des communications électroniques est ainsi modifié :
 
@@ -267,7 +267,7 @@ De même sexe que celui auquel il succède. » ;
 
 « Ce nouveau membre est de même sexe que celui qu’il remplace. »
 
-Article 20 sexies (nouveau)
+#### Article 20 sexies (nouveau)
 
 Le I de l’article 6 de la loi n° 2004‑575 du 21 juin 2004 pour la confiance dans l’économie
 Numérique est ainsi modifié :
@@ -277,7 +277,7 @@ Numérique est ainsi modifié :
 2° Au premier alinéa du 3 et à la fin du premier alinéa et, deux fois, à la seconde phrase du
 Quatrième alinéa du 7, le mot : « illicites » est remplacé par le mot : « illégales ».
 
-Article 20 septies (nouveau)
+#### Article 20 septies (nouveau)
 
 L’article 323‑1 du code pénal est complété par un alinéa ainsi rédigé :
 
@@ -286,11 +286,11 @@ De peine si elle a immédiatement averti l’autorité administrative ou judicia
 Système de traitement automatisé de données en cause d’un risque d’atteinte aux données ou au
 Fonctionnement du système. »
 
-Section 2
+### Section 2
 
 Portabilité et récupération des données
 
-Article 21 A (nouveau)
+#### Article 21 A (nouveau)
 
 L’article L. 131‑2 du code de l’éducation est complété par un alinéa ainsi rédigé :
 
@@ -298,7 +298,7 @@ L’article L. 131‑2 du code de l’éducation est complété par un alinéa a
 Peuvent organiser par convention la récupération par les élèves de leurs données scolaires sous
 Format numérique. »
 
-Article 21
+#### Article 21
 
 I. – Le livre I<sup>er</sup> du code de la consommation est ainsi modifié :
 
@@ -389,11 +389,11 @@ Références : « 12, 15 et 20 ».
 II. – Le présent article entre en vigueur dix‑huit mois à compter de la date de publication de la
 Présente loi.
 
-Section 3
+### Section 3
 
 Loyauté des plateformes et information des consommateurs
 
-Article 22
+#### Article 22
 
 Le chapitre I<sup>er</sup> du livre I<sup>er</sup> du code de la consommation est ainsi modifié :
 
@@ -405,7 +405,8 @@ A) Le premier alinéa est remplacé par huit alinéas ainsi rédigés :
 
 « Sans préjudice de la loi n° 2004‑575 du 21 juin 2004 pour la confiance dans l’économie numérique,
 Est qualifiée d’opérateur de plateforme en ligne toute personne physique ou morale proposant, à
-Titre professionnel, de manière rémunérée ou non, un service de communication en ligne reposant sur
+# Titre professionnel, de manière rémunérée ou non, un service de communication en ligne reposant
+sur
 :
 
 « 1° Le classement ou le référencement, au moyen d’algorithmes informatiques, de contenus, de biens
@@ -437,7 +438,7 @@ B) Aux deuxième et troisième alinéas, les mots : « la personne mentionnée a
 Présent article est également tenue » sont remplacés par les mots : « l’opérateur de plateforme en
 Ligne est également tenu ».
 
-Article 22 bis (nouveau)
+#### Article 22 bis (nouveau)
 
 L’article L. 111‑7 du code de la consommation est complété par trois alinéas ainsi rédigés :
 
@@ -452,7 +453,7 @@ De l’Union européenne, dirigent par tout moyen leur activité vers le territo
 Le consommateur a sa résidence habituelle ou causent un dommage à un consommateur sur le territoire
 Français. »
 
-Article 23
+#### Article 23
 
 I. – Après l’article L. 111‑5‑1 du code de la consommation, sont insérés des articles L. 111‑5‑2
 Et L. 111‑5‑2‑1 ainsi rédigés :
@@ -500,7 +501,7 @@ Leurs obligations de clarté, de transparence et de loyauté, de définir des in
 D’apprécier le respect de ces obligations et de rendre périodiquement publics les résultats de
 L’évaluation des indicateurs mentionnés.
 
-Article 23 bis (nouveau)
+#### Article 23 bis (nouveau)
 
 I. – Les plateformes ayant pour objet des prestations de services proposées par des professions
 Réglementées doivent recevoir un avis conforme de l’institution chargée de l’application des règles
@@ -516,7 +517,7 @@ Réglementée concernée.
 III. – Les modalités d’application du référentiel, de la procédure de labellisation et de
 L’accréditation sont fixées par décret en Conseil d’État.
 
-Article 23 ter (nouveau)
+#### Article 23 ter (nouveau)
 
 L’article L. 631‑7‑1 A du code de la construction et de l’habitation est complété par un alinéa
 Ainsi rédigé :
@@ -528,7 +529,7 @@ Assurent un service de mise en relation en vue de la location d’hébergements.
 Justification de la qualité de propriétaire ou de l’autorisation du bailleur est puni, pour le
 Loueur et les professionnels précités, conformément aux articles L. 651‑2 et L. 651‑3. »
 
-Article 24
+#### Article 24
 
 Le chapitre I<sup>er</sup> du titre I<sup>er</sup> du livre I<sup>er</sup> du code de la
 Consommation est ainsi modifié :
@@ -558,7 +559,7 @@ Modalités et le contenu de ces informations. » ;
 2° À l’article L. 111‑6‑1, la référence : « et L. 111‑5‑1 » est remplacée par la référence : « à
 L. 111‑5‑3 ».
 
-Article 25
+#### Article 25
 
 I. – L’article L. 121‑83 du code de la consommation est ainsi modifié :
 

--- a/Titre II/Chapitre Ier - Environnement ouvert.md
+++ b/Titre II/Chapitre Ier - Environnement ouvert.md
@@ -1,7 +1,7 @@
 TITRE II
 
 La protection DES DROITS
-dans la société numérique
+Dans la société numérique
 
 Chapitre I<sup>er</sup>
 
@@ -13,169 +13,278 @@ Neutralité de l’internet
 
 Article 19
 
-Le titre I<sup>er</sup> du livre II du code des postes et des communications électroniques est ainsi modifié :
+Le titre I<sup>er</sup> du livre II du code des postes et des communications électroniques est
+Ainsi modifié :
 
-1° Après le 5° du II de l’article L. 32‑1, il est inséré un 5° bis ainsi rédigé :
+1° Après le 5° du II de l’article L. 32‑1, il est inséré un 5° bis ainsi rédigé :
 
-« 5° bis La neutralité de l’internet, définie au q du I de l’article L. 33‑1 ; »
+« 5° bis La neutralité de l’internet, définie au q du I de l’article L. 33‑1 ; »
 
-2° Le 2° de l’article L. 32‑4 est ainsi modifié :
+2° Le 2° de l’article L. 32‑4 est ainsi modifié :
 
-a) Après le mot : « trafic », sont insérés les mots : « , y compris de gestion, » ;
+A) Après le mot : « trafic », sont insérés les mots : « , y compris de gestion, » ;
 
-b) Sont ajoutés les mots : « , notamment en vue d’assurer le respect de la neutralité de l’internet mentionnée au q du I de l’article L. 33‑1 » ;
+B) Sont ajoutés les mots : « , notamment en vue d’assurer le respect de la neutralité de
+L’internet mentionnée au q du I de l’article L. 33‑1 » ;
 
-3° Le I de l’article L. 33‑1 est ainsi modifié :
+3° Le I de l’article L. 33‑1 est ainsi modifié :
 
-a) Après le o, il est inséré un q ainsi rédigé :
+A) Après le o, il est inséré un q ainsi rédigé :
 
-« q) La neutralité de l’internet, qui consiste à garantir l’accès à l’internet ouvert régi par le règlement (UE) 2015/2120 du Parlement européen et du Conseil du 25 novembre 2015 établissant des mesures relatives à l’accès à un internet ouvert et modifiant la directive 2002/22/CE concernant le service universel et les droits des utilisateurs au regard des réseaux et services de communications électroniques et le règlement (UE) n° 531/2012 concernant l’itinérance sur les réseaux publics de communications mobiles à l’intérieur de l’Union. » ;
+« q) La neutralité de l’internet, qui consiste à garantir l’accès à l’internet ouvert régi par le
+Règlement (UE) 2015/2120 du Parlement européen et du Conseil du 25 novembre 2015 établissant des
+Mesures relatives à l’accès à un internet ouvert et modifiant la directive 2002/22/CE concernant le
+Service universel et les droits des utilisateurs au regard des réseaux et services de communications
+électroniques et le règlement (UE) n° 531/2012 concernant l’itinérance sur les réseaux publics de
+Communications mobiles à l’intérieur de l’Union. » ;
 
-b) À la fin du dernier alinéa, la référence : « o » est remplacée par la référence : « q » ;
+B) À la fin du dernier alinéa, la référence : « o » est remplacée par la référence : « q » ;
 
-4° Au 3° de l’article L. 36‑7, après le mot : « Union », sont insérés les mots : « , du règlement (UE) 2015/2120 du Parlement européen et du Conseil du 25 novembre 2015 établissant des mesures relatives à l’internet ouvert et modifiant la directive 2002/22/CE concernant le service universel et les droits des utilisateurs au regard des réseaux et services de communications électroniques et le règlement (UE) n° 531/2012 concernant l’itinérance sur les réseaux publics de communications mobiles à l’intérieur de l’Union » ;
+4° Au 3° de l’article L. 36‑7, après le mot : « Union », sont insérés les mots : « , du règlement
+(UE) 2015/2120 du Parlement européen et du Conseil du 25 novembre 2015 établissant des mesures
+Relatives à l’internet ouvert et modifiant la directive 2002/22/CE concernant le service universel
+Et les droits des utilisateurs au regard des réseaux et services de communications électroniques et
+Le règlement (UE) n° 531/2012 concernant l’itinérance sur les réseaux publics de communications
+Mobiles à l’intérieur de l’Union » ;
 
-5° Le 5° du II de l’article L. 36‑8 est ainsi modifié :
+5° Le 5° du II de l’article L. 36‑8 est ainsi modifié :
 
-a) Après le mot : « acheminement », sont insérés les mots : « , y compris de gestion, » ;
+A) Après le mot : « acheminement », sont insérés les mots : « , y compris de gestion, » ;
 
-b) Sont ajoutés les mots : « , en vue notamment d’assurer le respect de la neutralité de l’internet mentionnée au q du I de l’article L. 33‑1 » ;
+B) Sont ajoutés les mots : « , en vue notamment d’assurer le respect de la neutralité de
+L’internet mentionnée au q du I de l’article L. 33‑1 » ;
 
-6° L’article L. 36‑11 est ainsi modifié :
+6° L’article L. 36‑11 est ainsi modifié :
 
-a) Après le mot : « réseau », la fin de la première phrase du premier alinéa est ainsi rédigée : « , des fournisseurs de services de communications électroniques, des fournisseurs de services de communication au public en ligne ou des prestataires de services d’envoi de recommandé électronique mentionnés à l’article L. 100. » ;
+A) Après le mot : « réseau », la fin de la première phrase du premier alinéa est ainsi rédigée : «
+, des fournisseurs de services de communications électroniques, des fournisseurs de services de
+Communication au public en ligne ou des prestataires de services d’envoi de recommandé électronique
+Mentionnés à l’article L. 100. » ;
 
-b) Après le mot : « réseau », la fin du premier alinéa du I est ainsi rédigée : « , par un fournisseur de services de communications électroniques, par un fournisseur de services de communication au public en ligne ou par un prestataire de services d’envoi de recommandé électronique : » ;
+B) Après le mot : « réseau », la fin du premier alinéa du I est ainsi rédigée : « , par un
+Fournisseur de services de communications électroniques, par un fournisseur de services de
+Communication au public en ligne ou par un prestataire de services d’envoi de recommandé
+électronique : » ;
 
-c) Après le troisième alinéa du même I, il est inséré un alinéa ainsi rédigé :
+C) Après le troisième alinéa du même I, il est inséré un alinéa ainsi rédigé :
 
-« – aux dispositions du règlement (UE) 2015/2120 du Parlement européen et du Conseil du 25 novembre 2015 établissant des mesures relatives à l’internet ouvert et modifiant la directive 2002/22/CE concernant le service universel et les droits des utilisateurs au regard des réseaux et services de communications électroniques et le règlement (UE) n° 531/2012 concernant l’itinérance sur les réseaux publics de communications mobiles à l’intérieur de l’Union ; »
+« – aux dispositions du règlement (UE) 2015/2120 du Parlement européen et du Conseil du 25 novembre
+2015 établissant des mesures relatives à l’internet ouvert et modifiant la directive 2002/22/CE
+Concernant le service universel et les droits des utilisateurs au regard des réseaux et services de
+Communications électroniques et le règlement (UE) n° 531/2012 concernant l’itinérance sur les
+Réseaux publics de communications mobiles à l’intérieur de l’Union ; »
 
-d) Le même I est complété par un alinéa ainsi rédigé :
+D) Le même I est complété par un alinéa ainsi rédigé :
 
-« Lorsque l’Autorité estime qu’il existe un risque caractérisé qu’un exploitant de réseau ou un fournisseur de services de communications électroniques ne respecte pas ses obligations, résultant des dispositions et prescriptions mentionnées au présent I, à l’échéance prévue initialement, elle peut mettre en demeure l’exploitant ou le fournisseur de s’y conformer à cette échéance. » ;
+« Lorsque l’Autorité estime qu’il existe un risque caractérisé qu’un exploitant de réseau ou un
+Fournisseur de services de communications électroniques ne respecte pas ses obligations, résultant
+Des dispositions et prescriptions mentionnées au présent I, à l’échéance prévue initialement, elle
+Peut mettre en demeure l’exploitant ou le fournisseur de s’y conformer à cette échéance. » ;
 
-e) À la première phrase du II, les mots : « ou un fournisseur de services de communications électroniques » sont remplacés par les mots : « , un fournisseur de services de communications électroniques ou un fournisseur de services de communication au public en ligne ».
+E) À la première phrase du II, les mots : « ou un fournisseur de services de communications
+électroniques » sont remplacés par les mots : « , un fournisseur de services de communications
+électroniques ou un fournisseur de services de communication au public en ligne ».
 
 Article 19 bis (nouveau)
 
-Le chapitre III du titre I<sup>er</sup> du livre I<sup>er</sup> de la première partie du code de la propriété intellectuelle est complété par un article L. 113‑11 ainsi rédigé :
+Le chapitre III du titre I<sup>er</sup> du livre I<sup>er</sup> de la première partie du code de
+La propriété intellectuelle est complété par un article L. 113‑11 ainsi rédigé :
 
-« Art. L. 113‑11. – Toute association régulièrement déclarée depuis au moins deux ans à la date des faits et se proposant, par ses statuts, de protéger la propriété intellectuelle, de défendre le domaine public ou de promouvoir la diffusion des savoirs peut exercer les droits reconnus à la partie civile et saisir le tribunal de grande instance afin de faire cesser tout obstacle à la libre réutilisation d’une œuvre entrée dans le domaine public. »
+« Art. L. 113‑11. – Toute association régulièrement déclarée depuis au moins deux ans à la date des
+Faits et se proposant, par ses statuts, de protéger la propriété intellectuelle, de défendre le
+Domaine public ou de promouvoir la diffusion des savoirs peut exercer les droits reconnus à la
+Partie civile et saisir le tribunal de grande instance afin de faire cesser tout obstacle à la libre
+Réutilisation d’une œuvre entrée dans le domaine public. »
 
 Article 20
 
-L’article L. 33‑1 du code des postes et des communications électroniques est complété par un VI ainsi rédigé :
+L’article L. 33‑1 du code des postes et des communications électroniques est complété par un VI
+Ainsi rédigé :
 
-« VI. – Aucune limitation technique ou contractuelle ne peut être apportée à un service d’accès à internet, qui aurait pour objet ou effet d’interdire à un utilisateur de ce service qui en fait la demande :
+« VI. – Aucune limitation technique ou contractuelle ne peut être apportée à un service d’accès à
+Internet, qui aurait pour objet ou effet d’interdire à un utilisateur de ce service qui en fait la
+Demande :
 
-« 1° D’accéder, depuis un point d’accès à internet, à des données enregistrées sur un équipement connecté à internet, par l’intermédiaire du service d’accès auquel il a souscrit ;
+« 1° D’accéder, depuis un point d’accès à internet, à des données enregistrées sur un équipement
+Connecté à internet, par l’intermédiaire du service d’accès auquel il a souscrit ;
 
-« 2° Ou de donner à des tiers accès à ces données. »
+« 2° Ou de donner à des tiers accès à ces données. »
 
 Article 20 bis A (nouveau)
 
-À compter du 1<sup>er</sup> janvier 2018, tout équipement terminal, au sens de l’article L. 32 du code des postes et des communications électroniques, destiné à la vente ou la location sur le territoire français est compatible avec la norme IPV6.
+À compter du 1<sup>er</sup> janvier 2018, tout équipement terminal, au sens de l’article L. 32 du
+Code des postes et des communications électroniques, destiné à la vente ou la location sur le
+Territoire français est compatible avec la norme IPV6.
 
 Article 20 bis (nouveau)
 
-Le code des postes et des communications électroniques est ainsi modifié :
+Le code des postes et des communications électroniques est ainsi modifié :
 
-1° L’article L. 32‑4 est ainsi modifié :
+1° L’article L. 32‑4 est ainsi modifié :
 
-a) Au début du premier alinéa, est ajoutée la mention : « I. – » ;
+A) Au début du premier alinéa, est ajoutée la mention : « I. – » ;
 
-b) Les cinquième et avant-dernier alinéas sont remplacés par un alinéa ainsi rédigé :
+B) Les cinquième et avant-dernier alinéas sont remplacés par un alinéa ainsi rédigé :
 
-« Ces enquêtes sont menées dans les conditions prévues aux II à IV du présent article et à l’article L. 32‑5. » ;
+« Ces enquêtes sont menées dans les conditions prévues aux II à IV du présent article et à
+L’article L. 32‑5. » ;
 
-c) Sont ajoutés des II à IV ainsi rédigés :
+C) Sont ajoutés des II à IV ainsi rédigés :
 
-« II. – Les fonctionnaires et agents du ministère chargé des communications électroniques et de l’Autorité de régulation des communications électroniques et des postes, habilités à cet effet par le ministre chargé des communications électroniques et assermentés dans des conditions fixées par décret en Conseil d’État, peuvent, pour l’exercice de leurs missions, opérer sur la voie publique, pénétrer entre 6 heures et 21 heures dans tous lieux utilisés à des fins professionnelles par les personnes mentionnées aux 1° et 2° du I du présent article, à l’exclusion des parties de ceux-ci affectés au domicile privé et accéder à tous moyens de transport à usage professionnel.
+« II. – Les fonctionnaires et agents du ministère chargé des communications électroniques et de
+L’Autorité de régulation des communications électroniques et des postes, habilités à cet effet par
+Le ministre chargé des communications électroniques et assermentés dans des conditions fixées par
+Décret en Conseil d’État, peuvent, pour l’exercice de leurs missions, opérer sur la voie publique,
+Pénétrer entre 6 heures et 21 heures dans tous lieux utilisés à des fins professionnelles par les
+Personnes mentionnées aux 1° et 2° du I du présent article, à l’exclusion des parties de ceux-ci
+Affectés au domicile privé et accéder à tous moyens de transport à usage professionnel.
 
-« Les fonctionnaires et agents mentionnés au premier alinéa du présent II peuvent demander la communication de tous documents nécessaires à l’accomplissement de leur mission, quel qu’en soit le support, et obtenir ou prendre copie de ces documents par tout moyen et sur tout support. Ils peuvent recueillir, sur place ou sur convocation, tout renseignement, tout document ou toute justification utiles. Ils peuvent accéder aux logiciels, aux programmes informatiques et aux données stockées et en demander la transcription par tout traitement approprié dans des documents directement utilisables pour les besoins du contrôle.
+« Les fonctionnaires et agents mentionnés au premier alinéa du présent II peuvent demander la
+Communication de tous documents nécessaires à l’accomplissement de leur mission, quel qu’en soit le
+Support, et obtenir ou prendre copie de ces documents par tout moyen et sur tout support. Ils
+Peuvent recueillir, sur place ou sur convocation, tout renseignement, tout document ou toute
+Justification utiles. Ils peuvent accéder aux logiciels, aux programmes informatiques et aux données
+Stockées et en demander la transcription par tout traitement approprié dans des documents
+Directement utilisables pour les besoins du contrôle.
 
-« Ils peuvent recourir à toute personne compétente. Cette personne :
+« Ils peuvent recourir à toute personne compétente. Cette personne :
 
-« 1° Peut les accompagner lors de leurs contrôles et prendre connaissance de tout document ou élément nécessaire à la réalisation de sa mission ou de son expertise ;
+« 1° Peut les accompagner lors de leurs contrôles et prendre connaissance de tout document ou
+élément nécessaire à la réalisation de sa mission ou de son expertise ;
 
-« 2° Ne peut effectuer aucun acte de procédure pénale ou administrative ;
+« 2° Ne peut effectuer aucun acte de procédure pénale ou administrative ;
 
-« 3° Ne peut utiliser les informations dont elle prend connaissance à cette occasion pour la mise en œuvre des pouvoirs de contrôle dont elle dispose, le cas échéant, en application d’autres dispositions législatives ou réglementaires ;
+« 3° Ne peut utiliser les informations dont elle prend connaissance à cette occasion pour la mise
+En œuvre des pouvoirs de contrôle dont elle dispose, le cas échéant, en application d’autres
+Dispositions législatives ou réglementaires ;
 
-« 4° Ne peut, sous peine des sanctions prévues à l’article 226‑13 du code pénal, divulguer les informations dont elle a eu connaissance dans ce cadre.
+« 4° Ne peut, sous peine des sanctions prévues à l’article 226‑13 du code pénal, divulguer les
+Informations dont elle a eu connaissance dans ce cadre.
 
-« Les fonctionnaires et agents mentionnés au premier alinéa du présent II peuvent procéder à des visites conjointes avec des agents, désignés par l’autorité administrative dont ils dépendent, appartenant à d’autres services de l’État ou de ses établissements publics.
+« Les fonctionnaires et agents mentionnés au premier alinéa du présent II peuvent procéder à des
+Visites conjointes avec des agents, désignés par l’autorité administrative dont ils dépendent,
+Appartenant à d’autres services de l’État ou de ses établissements publics.
 
-« Les visites et auditions donnent lieu à procès-verbal, dont une copie est transmise aux personnes intéressées. Ce procès-verbal fait foi jusqu’à preuve contraire.
+« Les visites et auditions donnent lieu à procès-verbal, dont une copie est transmise aux personnes
+Intéressées. Ce procès-verbal fait foi jusqu’à preuve contraire.
 
-« Les fonctionnaires et agents mentionnés au premier alinéa du présent II peuvent également procéder à toute constatation utile. Ils peuvent notamment, à partir d’un service de communication au public en ligne, consulter les données librement accessibles ou rendues accessibles, y compris par imprudence, par négligence ou par le fait d’un tiers. Ils peuvent retranscrire les données par tout traitement approprié dans des documents directement utilisables pour les besoins du contrôle. Un décret en Conseil d’État précise les conditions dans lesquelles ils procèdent à ces constatations.
+« Les fonctionnaires et agents mentionnés au premier alinéa du présent II peuvent également
+Procéder à toute constatation utile. Ils peuvent notamment, à partir d’un service de communication
+Au public en ligne, consulter les données librement accessibles ou rendues accessibles, y compris
+Par imprudence, par négligence ou par le fait d’un tiers. Ils peuvent retranscrire les données par
+Tout traitement approprié dans des documents directement utilisables pour les besoins du contrôle.
+Un décret en Conseil d’État précise les conditions dans lesquelles ils procèdent à ces
+Constatations.
 
-« III. – Les visites conduites en application du II du présent article peuvent être préalablement autorisées dans les conditions prévues à l’article L. 32‑5.
+« III. – Les visites conduites en application du II du présent article peuvent être préalablement
+Autorisées dans les conditions prévues à l’article L. 32‑5.
 
-« Lorsque ces visites n’ont pas été préalablement autorisées dans les conditions définies à l’article L. 32‑5, le responsable de locaux professionnels privés est informé de son droit d’opposition à la visite. Lorsqu’il exerce ce droit, la visite ne peut se dérouler qu’après l’autorisation du juge des libertés et de la détention du tribunal de grande instance, dans les conditions prévues au même article.
+« Lorsque ces visites n’ont pas été préalablement autorisées dans les conditions définies à
+L’article L. 32‑5, le responsable de locaux professionnels privés est informé de son droit
+D’opposition à la visite. Lorsqu’il exerce ce droit, la visite ne peut se dérouler qu’après
+L’autorisation du juge des libertés et de la détention du tribunal de grande instance, dans les
+Conditions prévues au même article.
 
-« Lorsque les lieux sont affectés au domicile privé, lorsque le responsable de locaux professionnels privés exerce le droit d’opposition prévu au présent article ou lorsqu’il est procédé à une saisie, les visites sont autorisées dans les conditions définies à l’article L. 32‑5.
+« Lorsque les lieux sont affectés au domicile privé, lorsque le responsable de locaux
+Professionnels privés exerce le droit d’opposition prévu au présent article ou lorsqu’il est procédé
+à une saisie, les visites sont autorisées dans les conditions définies à l’article L. 32‑5.
 
-« IV. – Dans le cadre des contrôles et enquêtes mentionnés au présent article et à l’article L. 32‑5, le secret professionnel ne peut être opposé aux fonctionnaires et agents mentionnés au II du présent article. Ces mêmes personnes peuvent, sans se voir opposer le secret professionnel, accéder à tout document ou élément d’information détenu par les services et établissements de l’État et des autres collectivités publiques. » ;
+« IV. – Dans le cadre des contrôles et enquêtes mentionnés au présent article et à l’article L.
+32‑5, le secret professionnel ne peut être opposé aux fonctionnaires et agents mentionnés au II du
+Présent article. Ces mêmes personnes peuvent, sans se voir opposer le secret professionnel, accéder
+à tout document ou élément d’information détenu par les services et établissements de l’État et des
+Autres collectivités publiques. » ;
 
-2° L’article L. 32‑5 est ainsi modifié :
+2° L’article L. 32‑5 est ainsi modifié :
 
-a) Le premier alinéa du I est remplacé par deux alinéas ainsi rédigés :
+A) Le premier alinéa du I est remplacé par deux alinéas ainsi rédigés :
 
-« I. – Les visites mentionnées au III de l’article L. 32‑4 sont autorisées par ordonnance du juge des libertés et de la détention du tribunal de grande instance dans le ressort duquel sont situés les lieux à visiter. Lorsque ces lieux sont situés dans le ressort de plusieurs juridictions et qu’une action simultanée doit être menée dans chacun d’eux, une ordonnance unique peut être délivrée par l’un des juges des libertés et de la détention compétents.
+« I. – Les visites mentionnées au III de l’article L. 32‑4 sont autorisées par ordonnance du juge
+Des libertés et de la détention du tribunal de grande instance dans le ressort duquel sont situés
+Les lieux à visiter. Lorsque ces lieux sont situés dans le ressort de plusieurs juridictions et
+Qu’une action simultanée doit être menée dans chacun d’eux, une ordonnance unique peut être délivrée
+Par l’un des juges des libertés et de la détention compétents.
 
-« Le juge vérifie que la demande d’autorisation est fondée ; cette demande doit comporter tous les éléments d’information en possession du demandeur de nature à justifier la visite et la saisie. » ;
+« Le juge vérifie que la demande d’autorisation est fondée ; cette demande doit comporter tous les
+éléments d’information en possession du demandeur de nature à justifier la visite et la saisie. » ;
 
-b) Le premier alinéa du II est complété par une phrase ainsi rédigée :
+B) Le premier alinéa du II est complété par une phrase ainsi rédigée :
 
-« L’ordonnance comporte la mention de la faculté pour l’occupant des lieux ou son représentant de faire appel à un conseil de son choix. L’exercice de cette faculté n’entraîne pas la suspension des opérations de visite et de saisie. » ;
+« L’ordonnance comporte la mention de la faculté pour l’occupant des lieux ou son représentant de
+Faire appel à un conseil de son choix. L’exercice de cette faculté n’entraîne pas la suspension des
+Opérations de visite et de saisie. » ;
 
-c) Le IV est ainsi modifié :
+C) Le IV est ainsi modifié :
 
-– à la deuxième phrase du premier alinéa, les mots : « de l’avocat » sont remplacés par les mots : « par le conseil » ;
+– à la deuxième phrase du premier alinéa, les mots : « de l’avocat » sont remplacés par les mots :
+« par le conseil » ;
 
-– le troisième alinéa est complété par deux phrases ainsi rédigées :
+– le troisième alinéa est complété par deux phrases ainsi rédigées :
 
-« Si l’inventaire sur place présente des difficultés, les pièces et documents saisis sont placés sous scellés. L’occupant des lieux ou son représentant est avisé qu’il peut assister à l’ouverture des scellés ; l’inventaire est alors établi. »
+« Si l’inventaire sur place présente des difficultés, les pièces et documents saisis sont placés
+Sous scellés. L’occupant des lieux ou son représentant est avisé qu’il peut assister à l’ouverture
+Des scellés ; l’inventaire est alors établi. »
 
 Article 20 ter (nouveau)
 
-À la première phrase du deuxième alinéa de l’article L. 125 du code des postes et des communications électroniques, après la deuxième occurrence du mot : « et », sont insérés les mots : « étudie les questions relatives à la neutralité de l’internet. Elle ».
+À la première phrase du deuxième alinéa de l’article L. 125 du code des postes et des
+Communications électroniques, après la deuxième occurrence du mot : « et », sont insérés les mots :
+« étudie les questions relatives à la neutralité de l’internet. Elle ».
 
 Article 20 quater (nouveau)
 
-I. – Aux premier et troisième alinéas de l’article L. 2, au II de l’article L. 2‑2, à la première phrase du premier alinéa de l’article L. 33‑2, à la dernière phrase de l’avant-dernier alinéa de l’article L. 34, au dernier alinéa de l’article L. 35‑1, à l’avant-dernier alinéa et à la première phrase du dernier alinéa de l’article L. 35‑2, à la première phrase du IV de l’article L. 35‑3, à la première phrase du dernier alinéa de l’article L. 35‑4, au dernier alinéa du I de l’article L. 44, à la première phrase de l’article L. 125, à la seconde phrase du premier alinéa de l’article L. 131 et à l’avant-dernière phrase du premier alinéa de l’article L. 135 du code des postes et des communications électroniques, les mots : « supérieure du service public des postes et des communications électroniques » sont remplacés par les mots : « parlementaire du numérique et des postes ».
+I. – Aux premier et troisième alinéas de l’article L. 2, au II de l’article L. 2‑2, à la première
+Phrase du premier alinéa de l’article L. 33‑2, à la dernière phrase de l’avant-dernier alinéa de
+L’article L. 34, au dernier alinéa de l’article L. 35‑1, à l’avant-dernier alinéa et à la première
+Phrase du dernier alinéa de l’article L. 35‑2, à la première phrase du IV de l’article L. 35‑3, à la
+Première phrase du dernier alinéa de l’article L. 35‑4, au dernier alinéa du I de l’article L. 44, à
+La première phrase de l’article L. 125, à la seconde phrase du premier alinéa de l’article L. 131 et
+à l’avant-dernière phrase du premier alinéa de l’article L. 135 du code des postes et des
+Communications électroniques, les mots : « supérieure du service public des postes et des
+Communications électroniques » sont remplacés par les mots : « parlementaire du numérique et des
+Postes ».
 
-II. – Aux premier et dernier alinéas du II et aux deux premiers alinéas du IV de l’article 6 et au dernier alinéa de l’article 38 de la loi n° 90‑568 du 2 juillet 1990 relative à l’organisation du service public de la poste et à France Télécom, les mots : « supérieure du service public des postes et des communications électroniques » sont remplacés par les mots : « parlementaire du numérique et des postes ».
+II. – Aux premier et dernier alinéas du II et aux deux premiers alinéas du IV de l’article 6 et au
+Dernier alinéa de l’article 38 de la loi n° 90‑568 du 2 juillet 1990 relative à l’organisation du
+Service public de la poste et à France Télécom, les mots : « supérieure du service public des postes
+Et des communications électroniques » sont remplacés par les mots : « parlementaire du numérique et
+Des postes ».
 
 Article 20 quinquies (nouveau)
 
-L’article L. 130 du code des postes et des communications électroniques est ainsi modifié :
+L’article L. 130 du code des postes et des communications électroniques est ainsi modifié :
 
-1° À la première phrase du premier alinéa, après le mot : « est », sont insérés les mots : « une autorité administrative indépendante » ;
+1° À la première phrase du premier alinéa, après le mot : « est », sont insérés les mots : « une
+Autorité administrative indépendante » ;
 
-2° Après le premier alinéa, il est inséré un alinéa ainsi rédigé :
+2° Après le premier alinéa, il est inséré un alinéa ainsi rédigé :
 
-« Parmi les membres de l’autorité, l’écart entre le nombre de femmes et le nombre d’hommes ne peut être supérieur à un. Pour la nomination des membres autres que le président, le nouveau membre est de même sexe que celui auquel il succède. » ;
+« Parmi les membres de l’autorité, l’écart entre le nombre de femmes et le nombre d’hommes ne peut
+être supérieur à un. Pour la nomination des membres autres que le président, le nouveau membre est
+De même sexe que celui auquel il succède. » ;
 
-3° Le neuvième alinéa est complété par une phrase ainsi rédigée :
+3° Le neuvième alinéa est complété par une phrase ainsi rédigée :
 
-« Ce nouveau membre est de même sexe que celui qu’il remplace. »
+« Ce nouveau membre est de même sexe que celui qu’il remplace. »
 
 Article 20 sexies (nouveau)
 
-Le I de l’article 6 de la loi n° 2004‑575 du 21 juin 2004 pour la confiance dans l’économie numérique est ainsi modifié :
+Le I de l’article 6 de la loi n° 2004‑575 du 21 juin 2004 pour la confiance dans l’économie
+Numérique est ainsi modifié :
 
-1° Au premier alinéa du 2 et au 4, le mot : « illicite » est remplacé par le mot : « illégal » ;
+1° Au premier alinéa du 2 et au 4, le mot : « illicite » est remplacé par le mot : « illégal » ;
 
-2° Au premier alinéa du 3 et à la fin du premier alinéa et, deux fois, à la seconde phrase du quatrième alinéa du 7, le mot : « illicites » est remplacé par le mot : « illégales ».
+2° Au premier alinéa du 3 et à la fin du premier alinéa et, deux fois, à la seconde phrase du
+Quatrième alinéa du 7, le mot : « illicites » est remplacé par le mot : « illégales ».
 
 Article 20 septies (nouveau)
 
-L’article 323‑1 du code pénal est complété par un alinéa ainsi rédigé :
+L’article 323‑1 du code pénal est complété par un alinéa ainsi rédigé :
 
-« Toute personne qui a tenté de commettre ou commis le délit prévu au présent article est exempte de peine si elle a immédiatement averti l’autorité administrative ou judiciaire ou le responsable du système de traitement automatisé de données en cause d’un risque d’atteinte aux données ou au fonctionnement du système. »
+« Toute personne qui a tenté de commettre ou commis le délit prévu au présent article est exempte
+De peine si elle a immédiatement averti l’autorité administrative ou judiciaire ou le responsable du
+Système de traitement automatisé de données en cause d’un risque d’atteinte aux données ou au
+Fonctionnement du système. »
 
 Section 2
 
@@ -183,65 +292,102 @@ Portabilité et récupération des données
 
 Article 21 A (nouveau)
 
-L’article L. 131‑2 du code de l’éducation est complété par un alinéa ainsi rédigé :
+L’article L. 131‑2 du code de l’éducation est complété par un alinéa ainsi rédigé :
 
-« Dans le cas où l’équipement nécessaire est disponible, l’État et les collectivités territoriales peuvent organiser par convention la récupération par les élèves de leurs données scolaires sous format numérique. »
+« Dans le cas où l’équipement nécessaire est disponible, l’État et les collectivités territoriales
+Peuvent organiser par convention la récupération par les élèves de leurs données scolaires sous
+Format numérique. »
 
 Article 21
 
-I. – Le livre I<sup>er</sup> du code de la consommation est ainsi modifié :
+I. – Le livre I<sup>er</sup> du code de la consommation est ainsi modifié :
 
-1° Le chapitre I<sup>er</sup> du titre II est complété par une section 20 ainsi rédigée :
+1° Le chapitre I<sup>er</sup> du titre II est complété par une section 20 ainsi rédigée :
 
-« Section 20
+« Section 20
 
-« Récupération et portabilité de données
+« Récupération et portabilité de données
 
-« Art. L. 121‑120. – Le consommateur dispose en toutes circonstances d’un droit de récupération de ses données, partiellement et intégralement, dans les conditions prévues à la présente section.
+« Art. L. 121‑120. – Le consommateur dispose en toutes circonstances d’un droit de récupération de
+Ses données, partiellement et intégralement, dans les conditions prévues à la présente section.
 
-« Sous‑section 1
+« Sous‑section 1
 
-« Services de courrier électronique
+« Services de courrier électronique
 
-« Art. L. 121‑121. – Tout fournisseur d’un service de courrier électronique qui comprend la mise à disposition d’une adresse de courrier électronique doit proposer une fonctionnalité gratuite permettant au consommateur de transférer, partiellement et intégralement, les messages qu’il a émis ou reçus au moyen de ce service et qui sont conservés par un système de traitement automatisé mis en œuvre par ce fournisseur, ainsi que sa liste de contacts, vers un autre fournisseur de service de courrier électronique comprenant la mise à disposition d’une adresse de courrier électronique, dans la limite de la capacité de stockage de ce nouveau service.
+« Art. L. 121‑121. – Tout fournisseur d’un service de courrier électronique qui comprend la mise à
+Disposition d’une adresse de courrier électronique doit proposer une fonctionnalité gratuite
+Permettant au consommateur de transférer, partiellement et intégralement, les messages qu’il a émis
+Ou reçus au moyen de ce service et qui sont conservés par un système de traitement automatisé mis en
+œuvre par ce fournisseur, ainsi que sa liste de contacts, vers un autre fournisseur de service de
+Courrier électronique comprenant la mise à disposition d’une adresse de courrier électronique, dans
+La limite de la capacité de stockage de ce nouveau service.
 
-« À cette fin, il ne peut refuser de fournir à cet autre fournisseur les informations nécessaires à la mise en place des fonctionnalités mentionnées au premier alinéa, notamment celles relatives à leurs règles techniques et aux standards applicables.
+« À cette fin, il ne peut refuser de fournir à cet autre fournisseur les informations nécessaires à
+La mise en place des fonctionnalités mentionnées au premier alinéa, notamment celles relatives à
+Leurs règles techniques et aux standards applicables.
 
-« Ce fournisseur informe le consommateur de manière loyale, claire et transparente du droit mentionné au premier alinéa.
+« Ce fournisseur informe le consommateur de manière loyale, claire et transparente du droit
+Mentionné au premier alinéa.
 
-« La résiliation ou la désactivation du service s’accompagnent d’une offre gratuite permettant au consommateur de continuer, pour une durée de six mois à compter de la date de résiliation ou de désactivation, à bénéficier des fonctions de réception et d’envoi de courrier électronique à partir de l’adresse électronique qui lui était initialement attribuée.
+« La résiliation ou la désactivation du service s’accompagnent d’une offre gratuite permettant au
+Consommateur de continuer, pour une durée de six mois à compter de la date de résiliation ou de
+Désactivation, à bénéficier des fonctions de réception et d’envoi de courrier électronique à partir
+De l’adresse électronique qui lui était initialement attribuée.
 
-« Sous‑section 2
+« Sous‑section 2
 
-« Récupération des données stockées en ligne
+« Récupération des données stockées en ligne
 
-« Art. L. 121‑122. – Sans préjudice des dispositions protégeant le secret en matière commerciale et industrielle et des droits de propriété intellectuelle, tout fournisseur d’un service de communication au public en ligne propose au consommateur une fonctionnalité gratuite permettant la récupération licite :
+« Art. L. 121‑122. – Sans préjudice des dispositions protégeant le secret en matière commerciale et
+Industrielle et des droits de propriété intellectuelle, tout fournisseur d’un service de
+Communication au public en ligne propose au consommateur une fonctionnalité gratuite permettant la
+Récupération licite :
 
-« 1° De tous les fichiers mis en ligne par le consommateur ;
+« 1° De tous les fichiers mis en ligne par le consommateur ;
 
-« 2° De toutes les données résultant de l’utilisation du compte d’utilisateur du consommateur et consultables en ligne par celui-ci, dans un standard ouvert et aisément réutilisable, lisible par une machine ;
+« 2° De toutes les données résultant de l’utilisation du compte d’utilisateur du consommateur et
+Consultables en ligne par celui-ci, dans un standard ouvert et aisément réutilisable, lisible par
+Une machine ;
 
-« 3° (nouveau) Des autres données associées au compte d’utilisateur du consommateur dont la récupération est pertinente pour le changement de fournisseur dans un secteur économique ou industriel. Les données nécessaires sont précisées par voie réglementaire.
+« 3° (nouveau) Des autres données associées au compte d’utilisateur du consommateur dont la
+Récupération est pertinente pour le changement de fournisseur dans un secteur économique ou
+Industriel. Les données nécessaires sont précisées par voie réglementaire.
 
-« La fonctionnalité prévue au premier alinéa permet au consommateur de récupérer, par une requête unique, l’ensemble des fichiers ou données concernés. Le fournisseur prend toutes les mesures nécessaires à cette fin, en termes d’interface de programmation et de transmission des informations nécessaires au changement de fournisseur.
+« La fonctionnalité prévue au premier alinéa permet au consommateur de récupérer, par une requête
+Unique, l’ensemble des fichiers ou données concernés. Le fournisseur prend toutes les mesures
+Nécessaires à cette fin, en termes d’interface de programmation et de transmission des informations
+Nécessaires au changement de fournisseur.
 
-« Lorsque les données collectées auprès du consommateur ne peuvent pas être récupérées dans un standard ouvert et aisément réutilisable, le fournisseur de service de communication au public en ligne en informe le consommateur de façon claire et transparente. Le cas échéant, il l’informe des modalités alternatives de récupération de ces données et précise les caractéristiques techniques du format du fichier de récupération, notamment son caractère ouvert et interopérable.
+« Lorsque les données collectées auprès du consommateur ne peuvent pas être récupérées dans un
+Standard ouvert et aisément réutilisable, le fournisseur de service de communication au public en
+Ligne en informe le consommateur de façon claire et transparente. Le cas échéant, il l’informe des
+Modalités alternatives de récupération de ces données et précise les caractéristiques techniques du
+Format du fichier de récupération, notamment son caractère ouvert et interopérable.
 
-« Un décret précise les modalités d’application du présent article.
+« Un décret précise les modalités d’application du présent article.
 
-« Sous‑section 3
+« Sous‑section 3
 
-« Champ d’application et sanctions
+« Champ d’application et sanctions
 
-« Art. L. 121‑123. – La présente section est applicable aux services fournis aux professionnels pour l’exercice de leurs activités à titre principal ou accessoire, dans des conditions fixées par le contrat qui régit cette relation de service.
+« Art. L. 121‑123. – La présente section est applicable aux services fournis aux professionnels
+Pour l’exercice de leurs activités à titre principal ou accessoire, dans des conditions fixées par
+Le contrat qui régit cette relation de service.
 
-« Art. L. 121‑124. – Tout manquement aux articles L. 121‑121 et L. 121‑122 est passible d’une amende administrative dont le montant ne peut excéder 3 000 € pour une personne physique et 15 000 € pour une personne morale. L’amende est prononcée dans les conditions prévues à l’article L. 141‑1‑2. 
+« Art. L. 121‑124. – Tout manquement aux articles L. 121‑121 et L. 121‑122 est passible d’une
+Amende administrative dont le montant ne peut excéder 3 000 € pour une personne physique et 15 000 €
+Pour une personne morale. L’amende est prononcée dans les conditions prévues à l’article L. 141‑1‑2.
 
-« Art. L. 121‑125. – La présente section ne s’applique pas aux fournisseurs d’un service de communication au public en ligne dont le nombre de comptes utilisateurs ayant fait l’objet d’une connexion au cours des six derniers mois est inférieur à un seuil fixé par décret. » ;
+« Art. L. 121‑125. – La présente section ne s’applique pas aux fournisseurs d’un service de
+Communication au public en ligne dont le nombre de comptes utilisateurs ayant fait l’objet d’une
+Connexion au cours des six derniers mois est inférieur à un seuil fixé par décret. » ;
 
-2° Au 2° du I de l’article L. 141‑1, les références : « 12 et 15 » sont remplacées par les références : « 12, 15 et 20 ».
+2° Au 2° du I de l’article L. 141‑1, les références : « 12 et 15 » sont remplacées par les
+Références : « 12, 15 et 20 ».
 
-II. – Le présent article entre en vigueur dix‑huit mois à compter de la date de publication de la présente loi.
+II. – Le présent article entre en vigueur dix‑huit mois à compter de la date de publication de la
+Présente loi.
 
 Section 3
 
@@ -249,109 +395,187 @@ Loyauté des plateformes et information des consommateurs
 
 Article 22
 
-Le chapitre I<sup>er</sup> du livre I<sup>er</sup> du code de la consommation est ainsi modifié :
+Le chapitre I<sup>er</sup> du livre I<sup>er</sup> du code de la consommation est ainsi modifié :
 
-1° (Supprimé)
+1° (Supprimé)
 
-2° L’article L. 111‑5‑1 du code de la consommation est ainsi modifié :
+2° L’article L. 111‑5‑1 du code de la consommation est ainsi modifié :
 
-a) Le premier alinéa est remplacé par huit alinéas ainsi rédigés :
+A) Le premier alinéa est remplacé par huit alinéas ainsi rédigés :
 
-« Sans préjudice de la loi n° 2004‑575 du 21 juin 2004 pour la confiance dans l’économie numérique, est qualifiée d’opérateur de plateforme en ligne toute personne physique ou morale proposant, à titre professionnel, de manière rémunérée ou non, un service de communication en ligne reposant sur :
+« Sans préjudice de la loi n° 2004‑575 du 21 juin 2004 pour la confiance dans l’économie numérique,
+Est qualifiée d’opérateur de plateforme en ligne toute personne physique ou morale proposant, à
+Titre professionnel, de manière rémunérée ou non, un service de communication en ligne reposant sur
+:
 
-« 1° Le classement ou le référencement, au moyen d’algorithmes informatiques, de contenus, de biens ou de services proposés ou mis en ligne par des tiers ;
+« 1° Le classement ou le référencement, au moyen d’algorithmes informatiques, de contenus, de biens
+Ou de services proposés ou mis en ligne par des tiers ;
 
-« 2° Ou la mise en relation de plusieurs parties en vue de la vente d’un bien, de la fourniture d’un service ou de l’échange ou du partage d’un contenu, d’un bien ou d’un service.
+« 2° Ou la mise en relation de plusieurs parties en vue de la vente d’un bien, de la fourniture
+D’un service ou de l’échange ou du partage d’un contenu, d’un bien ou d’un service.
 
-« Tout opérateur de plateforme en ligne est tenu de délivrer au consommateur une information loyale, claire et transparente sur les conditions générales d’utilisation du service d’intermédiation qu’il propose et sur les modalités de référencement, de classement et de déréférencement des contenus, des biens ou des services auxquels ce service permet d’accéder. L’opérateur fait apparaître clairement, grâce à une signalisation explicite, l’existence :
+« Tout opérateur de plateforme en ligne est tenu de délivrer au consommateur une information
+Loyale, claire et transparente sur les conditions générales d’utilisation du service
+D’intermédiation qu’il propose et sur les modalités de référencement, de classement et de
+Déréférencement des contenus, des biens ou des services auxquels ce service permet d’accéder.
+L’opérateur fait apparaître clairement, grâce à une signalisation explicite, l’existence :
 
-« a) D’une relation contractuelle, dès lors que le contrat sous-jacent contient des stipulations relatives au classement des contenus, des biens ou des services proposés par la personne morale référencée ;
+« a) D’une relation contractuelle, dès lors que le contrat sous-jacent contient des stipulations
+Relatives au classement des contenus, des biens ou des services proposés par la personne morale
+Référencée ;
 
-« b) D’un lien capitalistique, dès lors qu’il influence le classement des contenus, des biens ou des services proposés par la personne morale référencée ;
+« b) D’un lien capitalistique, dès lors qu’il influence le classement des contenus, des biens ou
+Des services proposés par la personne morale référencée ;
 
-« c) D’une rémunération directe par les personnes morales référencées et, le cas échéant, l’impact de celle-ci sur le classement des contenus, biens ou services proposés. 
+« c) D’une rémunération directe par les personnes morales référencées et, le cas échéant, l’impact
+De celle-ci sur le classement des contenus, biens ou services proposés.
 
-« Le détail des informations à délivrer au consommateur à ce titre prend la forme d’une description générique et intelligible dans les conditions générales d’utilisation de la plateforme en ligne. » ;
+« Le détail des informations à délivrer au consommateur à ce titre prend la forme d’une description
+Générique et intelligible dans les conditions générales d’utilisation de la plateforme en ligne. » ;
 
-b) Aux deuxième et troisième alinéas, les mots : « la personne mentionnée au premier alinéa du présent article est également tenue » sont remplacés par les mots : « l’opérateur de plateforme en ligne est également tenu ».
+B) Aux deuxième et troisième alinéas, les mots : « la personne mentionnée au premier alinéa du
+Présent article est également tenue » sont remplacés par les mots : « l’opérateur de plateforme en
+Ligne est également tenu ».
 
 Article 22 bis (nouveau)
 
-L’article L. 111‑7 du code de la consommation est complété par trois alinéas ainsi rédigés :
+L’article L. 111‑7 du code de la consommation est complété par trois alinéas ainsi rédigés :
 
-« Sont soumises aux obligations prévues au présent chapitre les personnes physiques ou morales exerçant à titre professionnel :
+« Sont soumises aux obligations prévues au présent chapitre les personnes physiques ou morales
+Exerçant à titre professionnel :
 
-« 1° Établies sur le territoire français ou sur le territoire d’un État membre de l’Union européenne ;
+« 1° Établies sur le territoire français ou sur le territoire d’un État membre de l’Union
+Européenne ;
 
-« 2° Ou qui, sans être établies sur le territoire français ou sur le territoire d’un État membre de de l’Union européenne, dirigent par tout moyen leur activité vers le territoire français sur lequel le consommateur a sa résidence habituelle ou causent un dommage à un consommateur sur le territoire français. »
+« 2° Ou qui, sans être établies sur le territoire français ou sur le territoire d’un État membre de
+De l’Union européenne, dirigent par tout moyen leur activité vers le territoire français sur lequel
+Le consommateur a sa résidence habituelle ou causent un dommage à un consommateur sur le territoire
+Français. »
 
 Article 23
 
-I. – Après l’article L. 111‑5‑1 du code de la consommation, sont insérés des articles L. 111‑5‑2 et L. 111‑5‑2‑1 ainsi rédigés :
+I. – Après l’article L. 111‑5‑1 du code de la consommation, sont insérés des articles L. 111‑5‑2
+Et L. 111‑5‑2‑1 ainsi rédigés :
 
-« Art. L. 111‑5‑2. – Les opérateurs de plateformes en ligne dont l’activité dépasse un seuil de nombre de connexions défini par décret élaborent et diffusent aux consommateurs des bonnes pratiques visant à renforcer les obligations de clarté, de transparence et de loyauté mentionnées à l’article L. 111‑5‑1.
+« Art. L. 111‑5‑2. – Les opérateurs de plateformes en ligne dont l’activité dépasse un seuil de
+Nombre de connexions défini par décret élaborent et diffusent aux consommateurs des bonnes pratiques
+Visant à renforcer les obligations de clarté, de transparence et de loyauté mentionnées à l’article
+L. 111‑5‑1.
 
-« L’autorité administrative compétente peut procéder à des enquêtes dans les conditions prévues au premier alinéa du II de l’article L. 141‑1 afin d’évaluer et de comparer les pratiques des opérateurs de plateformes en ligne mentionnées au premier alinéa du présent article. Elle peut, à cette fin, recueillir auprès de ces opérateurs les informations utiles à l’exercice de cette mission. Elle diffuse périodiquement les résultats de ces évaluations et de ces comparaisons et rend publique la liste des plateformes en ligne qui ne respectent pas leurs obligations au titre de l’article L. 111‑5‑1.
+« L’autorité administrative compétente peut procéder à des enquêtes dans les conditions prévues au
+Premier alinéa du II de l’article L. 141‑1 afin d’évaluer et de comparer les pratiques des
+Opérateurs de plateformes en ligne mentionnées au premier alinéa du présent article. Elle peut, à
+Cette fin, recueillir auprès de ces opérateurs les informations utiles à l’exercice de cette
+Mission. Elle diffuse périodiquement les résultats de ces évaluations et de ces comparaisons et rend
+Publique la liste des plateformes en ligne qui ne respectent pas leurs obligations au titre de
+L’article L. 111‑5‑1.
 
-« Un décret précise les modalités d’application du présent article.
+« Un décret précise les modalités d’application du présent article.
 
-« Art. L. 111‑5‑2‑1 (nouveau). – Les opérateurs de plateformes en ligne mentionnés à l’article L. 111‑5‑2 par l’intermédiaire desquels des contenus illicites sont susceptibles d’être diffusés à grande échelle à destination des consommateurs résidant en France :
+« Art. L. 111‑5‑2‑1 (nouveau). – Les opérateurs de plateformes en ligne mentionnés à l’article L.
+111‑5‑2 par l’intermédiaire desquels des contenus illicites sont susceptibles d’être diffusés à
+Grande échelle à destination des consommateurs résidant en France :
 
-« 1° Désignent une personne physique comme leur représentant légal en France ;
+« 1° Désignent une personne physique comme leur représentant légal en France ;
 
-« 2° Élaborent des bonnes pratiques visant à lutter contre la mise à la disposition du public, par leur entremise, de contenus illicites, notamment par la mise en œuvre de dispositifs techniques de reconnaissance automatisée de tels contenus ;
+« 2° Élaborent des bonnes pratiques visant à lutter contre la mise à la disposition du public, par
+Leur entremise, de contenus illicites, notamment par la mise en œuvre de dispositifs techniques de
+Reconnaissance automatisée de tels contenus ;
 
-« 3° Définissent des indicateurs permettant d’apprécier le respect des lois et règlements relatifs aux contenus qu’ils mettent à la disposition du public ;
+« 3° Définissent des indicateurs permettant d’apprécier le respect des lois et règlements relatifs
+Aux contenus qu’ils mettent à la disposition du public ;
 
-« 4° Rendent périodiquement publics les résultats de l’évaluation des indicateurs mentionnés au 3°.
+« 4° Rendent périodiquement publics les résultats de l’évaluation des indicateurs mentionnés au 3°.
 
-« Les informations mentionnées aux 1° à 4° sont communiquées à l’autorité administrative compétente. »
+« Les informations mentionnées aux 1° à 4° sont communiquées à l’autorité administrative
+Compétente. »
 
-II (nouveau). – À titre expérimental et pour une durée de trois ans à compter de la promulgation de la présente loi, le Gouvernement définit, par voie réglementaire, les conditions de mise en place et de gestion d’une plateforme d’échange citoyen qui permet, dans une logique participative, de recueillir et de comparer des avis d’utilisateurs sur le respect des obligations des opérateurs de plateforme en ligne mentionnées à l’article L. 111‑5‑1 du code de la consommation, de mettre en place des outils d’évaluation de leurs pratiques, d’élaborer des bonnes pratiques visant à renforcer leurs obligations de clarté, de transparence et de loyauté, de définir des indicateurs permettant d’apprécier le respect de ces obligations et de rendre périodiquement publics les résultats de l’évaluation des indicateurs mentionnés.
+II (nouveau). – À titre expérimental et pour une durée de trois ans à compter de la promulgation
+De la présente loi, le Gouvernement définit, par voie réglementaire, les conditions de mise en place
+Et de gestion d’une plateforme d’échange citoyen qui permet, dans une logique participative, de
+Recueillir et de comparer des avis d’utilisateurs sur le respect des obligations des opérateurs de
+Plateforme en ligne mentionnées à l’article L. 111‑5‑1 du code de la consommation, de mettre en
+Place des outils d’évaluation de leurs pratiques, d’élaborer des bonnes pratiques visant à renforcer
+Leurs obligations de clarté, de transparence et de loyauté, de définir des indicateurs permettant
+D’apprécier le respect de ces obligations et de rendre périodiquement publics les résultats de
+L’évaluation des indicateurs mentionnés.
 
 Article 23 bis (nouveau)
 
-I. – Les plateformes ayant pour objet des prestations de services proposées par des professions réglementées doivent recevoir un avis conforme de l’institution chargée de l’application des règles déontologiques de ladite profession.
+I. – Les plateformes ayant pour objet des prestations de services proposées par des professions
+Réglementées doivent recevoir un avis conforme de l’institution chargée de l’application des règles
+Déontologiques de ladite profession.
 
-À défaut, la plateforme ne peut pas faire référence au titre de la profession réglementée dans sa communication auprès des consommateurs.
+À défaut, la plateforme ne peut pas faire référence au titre de la profession réglementée dans sa
+Communication auprès des consommateurs.
 
-II. – Au titre de l’article L. 115‑27 du code de la consommation, un label « qualité » attestant du respect des règles déontologiques est délivré par l’institution régissant la profession réglementée concernée.
+II. – Au titre de l’article L. 115‑27 du code de la consommation, un label « qualité » attestant
+Du respect des règles déontologiques est délivré par l’institution régissant la profession
+Réglementée concernée.
 
-III. – Les modalités d’application du référentiel, de la procédure de labellisation et de l’accréditation sont fixées par décret en Conseil d’État.
+III. – Les modalités d’application du référentiel, de la procédure de labellisation et de
+L’accréditation sont fixées par décret en Conseil d’État.
 
 Article 23 ter (nouveau)
 
-L’article L. 631‑7‑1 A du code de la construction et de l’habitation est complété par un alinéa ainsi rédigé :
+L’article L. 631‑7‑1 A du code de la construction et de l’habitation est complété par un alinéa
+Ainsi rédigé :
 
-« Le loueur du local à usage d’habitation qui le loue pour de courtes durées à une clientèle de passage qui n’y élit pas domicile doit justifier de sa qualité de propriétaire dudit local ou, s’il en est locataire, de l’autorisation du bailleur auprès des professionnels qui, opérant en ligne, assurent un service de mise en relation en vue de la location d’hébergements. Le défaut de justification de la qualité de propriétaire ou de l’autorisation du bailleur est puni, pour le loueur et les professionnels précités, conformément aux articles L. 651‑2 et L. 651‑3. »
+« Le loueur du local à usage d’habitation qui le loue pour de courtes durées à une clientèle de
+Passage qui n’y élit pas domicile doit justifier de sa qualité de propriétaire dudit local ou, s’il
+En est locataire, de l’autorisation du bailleur auprès des professionnels qui, opérant en ligne,
+Assurent un service de mise en relation en vue de la location d’hébergements. Le défaut de
+Justification de la qualité de propriétaire ou de l’autorisation du bailleur est puni, pour le
+Loueur et les professionnels précités, conformément aux articles L. 651‑2 et L. 651‑3. »
 
 Article 24
 
-Le chapitre I<sup>er</sup> du titre I<sup>er</sup> du livre I<sup>er</sup> du code de la consommation est ainsi modifié :
+Le chapitre I<sup>er</sup> du titre I<sup>er</sup> du livre I<sup>er</sup> du code de la
+Consommation est ainsi modifié :
 
-1° Après l’article L. 111‑5‑1, il est inséré un article L. 111‑5‑3 ainsi rédigé :
+1° Après l’article L. 111‑5‑1, il est inséré un article L. 111‑5‑3 ainsi rédigé :
 
-« Art. L. 111‑5‑3. – Sans préjudice des obligations d’information prévues à l’article 19 de la loi n° 2004‑575 du 21 juin 2004 pour la confiance dans l’économie numérique et aux articles L. 111‑5‑1 et L. 111‑5‑2 du présent code, toute personne physique ou morale dont l’activité consiste, à titre principal ou accessoire, à collecter, à modérer ou à diffuser des avis en ligne provenant de consommateurs est tenue de délivrer à ces consommateurs une information loyale, claire et transparente sur les modalités de contrôle des avis mis en ligne.
+« Art. L. 111‑5‑3. – Sans préjudice des obligations d’information prévues à l’article 19 de la loi
+N° 2004‑575 du 21 juin 2004 pour la confiance dans l’économie numérique et aux articles L. 111‑5‑1
+Et L. 111‑5‑2 du présent code, toute personne physique ou morale dont l’activité consiste, à titre
+Principal ou accessoire, à collecter, à modérer ou à diffuser des avis en ligne provenant de
+Consommateurs est tenue de délivrer à ces consommateurs une information loyale, claire et
+Transparente sur les modalités de contrôle des avis mis en ligne.
 
-« Elle précise si ces avis font ou non l’objet d’un contrôle et, si tel est le cas, elle indique les caractéristiques principales du contrôle mis en œuvre.
+« Elle précise si ces avis font ou non l’objet d’un contrôle et, si tel est le cas, elle indique
+Les caractéristiques principales du contrôle mis en œuvre.
 
-« Elle indique aux consommateurs dont l’avis en ligne a été rejeté les raisons qui justifient ce rejet.
+« Elle indique aux consommateurs dont l’avis en ligne a été rejeté les raisons qui justifient ce
+Rejet.
 
-« Elle met en place une fonctionnalité gratuite qui permet aux responsables des produits ou des services faisant l’objet d’un avis en ligne de lui signaler un doute sur l’authenticité d’un avis, à condition que ce signalement soit motivé.
+« Elle met en place une fonctionnalité gratuite qui permet aux responsables des produits ou des
+Services faisant l’objet d’un avis en ligne de lui signaler un doute sur l’authenticité d’un avis, à
+Condition que ce signalement soit motivé.
 
-« Un décret, pris après avis de la Commission nationale de l’informatique et des libertés, fixe les modalités et le contenu de ces informations. » ;
+« Un décret, pris après avis de la Commission nationale de l’informatique et des libertés, fixe les
+Modalités et le contenu de ces informations. » ;
 
-2° À l’article L. 111‑6‑1, la référence : « et L. 111‑5‑1 » est remplacée par la référence : « à L. 111‑5‑3 ».
+2° À l’article L. 111‑6‑1, la référence : « et L. 111‑5‑1 » est remplacée par la référence : « à
+L. 111‑5‑3 ».
 
 Article 25
 
-I. – L’article L. 121‑83 du code de la consommation est ainsi modifié :
+I. – L’article L. 121‑83 du code de la consommation est ainsi modifié :
 
-1° Après le b, il est inséré un b bis ainsi rédigé :
+1° Après le b, il est inséré un b bis ainsi rédigé :
 
-« b bis) Les explications prévues au d du 1 de l’article 4 du règlement (UE) n° 2015/2120 du Parlement européen et du Conseil du 25 novembre 2015 établissant des mesures relatives à l’accès à un internet ouvert et modifiant la directive n° 2002/22/CE concernant le service universel et les droits des utilisateurs au regard des réseaux et services de communications électroniques et le règlement (UE) n° 531/2012 concernant l’itinérance sur les réseaux publics de communications mobiles à l’intérieur de l’Union ; »
+« b bis) Les explications prévues au d du 1 de l’article 4 du règlement (UE) n° 2015/2120 du
+Parlement européen et du Conseil du 25 novembre 2015 établissant des mesures relatives à l’accès à
+Un internet ouvert et modifiant la directive n° 2002/22/CE concernant le service universel et les
+Droits des utilisateurs au regard des réseaux et services de communications électroniques et le
+Règlement (UE) n° 531/2012 concernant l’itinérance sur les réseaux publics de communications mobiles
+à l’intérieur de l’Union ; »
 
-2° Le g est complété par les mots : « , de protection de la vie privée et des données à caractère personnel, ainsi que l’impact des limitations de volume, de débits ou d’autres paramètres sur la qualité de l’accès à internet, en particulier l’utilisation de contenus, d’applications et de services, y compris ceux bénéficiant d’une qualité optimisée ».
+2° Le g est complété par les mots : « , de protection de la vie privée et des données à caractère
+Personnel, ainsi que l’impact des limitations de volume, de débits ou d’autres paramètres sur la
+Qualité de l’accès à internet, en particulier l’utilisation de contenus, d’applications et de
+Services, y compris ceux bénéficiant d’une qualité optimisée ».
 
-II. – L’article L. 121‑83 du même code, dans sa rédaction résultant de la présente loi, est applicable aux contrats conclus ou reconduits après la publication de cette même loi.
+II. – L’article L. 121‑83 du même code, dans sa rédaction résultant de la présente loi, est
+Applicable aux contrats conclus ou reconduits après la publication de cette même loi.
 

--- a/Titre III/Chapitre II - Facilitation des usages.md
+++ b/Titre III/Chapitre II - Facilitation des usages.md
@@ -1,15 +1,15 @@
-Chapitre ii
+## Chapitre ii
 
 Facilitation des usages
 
-Article 40 AA (nouveau)
+#### Article 40 AA (nouveau)
 
 Le Gouvernement remet au Parlement, dans les trois mois suivant la promulgation de la présente
 Loi, un rapport sur les mesures nécessaires au développement des échanges dématérialisés, notamment
 L’identité numérique, la valeur probante des documents numériques ou numérisés et la certification
 De solutions de coffre-fort électronique.
 
-Article 40 A (nouveau)
+#### Article 40 A (nouveau)
 
 I. – À la première phrase de l’article L. 121‑47 du code de la consommation, dans sa rédaction
 Résultant de la loi n° 2014‑344 du 17 mars 2014 relative à la consommation, après le mot : «
@@ -19,11 +19,11 @@ II. – Au IV de l’article 145 de la loi n° 2014‑344 du 17 mars 2014 préci
 Tôt dix-huit mois après l’entrée en vigueur » sont remplacés par les mots : « dans un délai de six
 Mois à compter de la publication ».
 
-Section 1
+### Section 1
 
 Recommandé électronique
 
-Article 40
+#### Article 40
 
 I. – Le livre III du code des postes et des communications électroniques est ainsi modifié :
 
@@ -90,12 +90,12 @@ Insérés les mots : « ou une prestation de services d’envoi de recommandé �
 6° Au VII, après le mot : « opérateur », sont insérés les mots : « , pour un prestataire de
 Services d’envoi de recommandé électronique ».
 
-Section 2
+### Section 2
 
 Paiement par facturation
 De l’opérateur de communications électroniques
 
-Article 41
+#### Article 41
 
 I. – Le code monétaire et financier est ainsi modifié :
 
@@ -211,15 +211,16 @@ De l’article L. 521‑3 et aux deux premiers alinéas et aux trois derniers al
 311‑4 » est supprimée.
 
 II. – La date d’entrée en vigueur du présent article est fixée par décret conformément aux
-Articles 115 et 116 de la directive 2015/2366/UE du Parlement européen et du Conseil du 25 novembre
+#### Articles 115 et 116 de la directive 2015/2366/UE du Parlement européen et du Conseil du 25
+novembre
 2015 concernant les services de paiement dans le marché intérieur et modifiant les directives
 2002/65/CE, 2013/36/UE et le règlement (UE) n° 1099/2010 et abrogeant la directive 2007/64/CE.
 
-Section 3
+### Section 3
 
 Compétitions de jeux vidéo
 
-Article 42
+#### Article 42
 
 I. – Un agrément peut être délivré par le ministre chargé de la jeunesse aux organisateurs de
 Compétitions de jeux vidéo, notamment à dominante sportive, requérant la présence physique des
@@ -236,7 +237,7 @@ Joueurs, qui présentent des garanties visant à :
 II. – Un arrêté du ministre chargé de la jeunesse fixe la liste des logiciels de loisirs, sur un
 Support physique ou en ligne, s’appuyant sur une trame scénarisée ou des situations simulées, pour
 Lesquels les organisateurs de compétitions peuvent bénéficier de l’agrément prévu au I du présent
-Article.
+#### Article.
 
 Ces logiciels de loisirs font prédominer, dans l’issue de la compétition, les combinaisons de
 L’intelligence et l’habilité des joueurs, en mettant à leur disposition des commandes et des

--- a/Titre III/Chapitre II - Facilitation des usages.md
+++ b/Titre III/Chapitre II - Facilitation des usages.md
@@ -1,16 +1,23 @@
-chapitre ii
+Chapitre ii
 
 Facilitation des usages
 
 Article 40 AA (nouveau)
 
-Le Gouvernement remet au Parlement, dans les trois mois suivant la promulgation de la présente loi, un rapport sur les mesures nécessaires au développement des échanges dématérialisés, notamment l’identité numérique, la valeur probante des documents numériques ou numérisés et la certification de solutions de coffre-fort électronique.
+Le Gouvernement remet au Parlement, dans les trois mois suivant la promulgation de la présente
+Loi, un rapport sur les mesures nécessaires au développement des échanges dématérialisés, notamment
+L’identité numérique, la valeur probante des documents numériques ou numérisés et la certification
+De solutions de coffre-fort électronique.
 
 Article 40 A (nouveau)
 
-I. – À la première phrase de l’article L. 121‑47 du code de la consommation, dans sa rédaction résultant de la loi n° 2014‑344 du 17 mars 2014 relative à la consommation, après le mot : « destination », sont insérés les mots : « des numéros surtaxés ».
+I. – À la première phrase de l’article L. 121‑47 du code de la consommation, dans sa rédaction
+Résultant de la loi n° 2014‑344 du 17 mars 2014 relative à la consommation, après le mot : «
+Destination », sont insérés les mots : « des numéros surtaxés ».
 
-II. – Au IV de l’article 145 de la loi n° 2014‑344 du 17 mars 2014 précitée, les mots : « au plus tôt dix-huit mois après l’entrée en vigueur » sont remplacés par les mots : « dans un délai de six mois à compter de la publication ».
+II. – Au IV de l’article 145 de la loi n° 2014‑344 du 17 mars 2014 précitée, les mots : « au plus
+Tôt dix-huit mois après l’entrée en vigueur » sont remplacés par les mots : « dans un délai de six
+Mois à compter de la publication ».
 
 Section 1
 
@@ -18,110 +25,195 @@ Recommandé électronique
 
 Article 40
 
-I. – Le livre III du code des postes et des communications électroniques est ainsi modifié :
+I. – Le livre III du code des postes et des communications électroniques est ainsi modifié :
 
-1° L’intitulé est ainsi rédigé : « Autres services, dispositions communes et finales » ;
+1° L’intitulé est ainsi rédigé : « Autres services, dispositions communes et finales » ;
 
-2° Le titre I<sup>er</sup> devient le titre II et le titre II devient le titre III ;
+2° Le titre I<sup>er</sup> devient le titre II et le titre II devient le titre III ;
 
-3° Il est rétabli un titre I<sup>er</sup> ainsi rédigé :
+3° Il est rétabli un titre I<sup>er</sup> ainsi rédigé :
 
-« TITRE I<sup>er</sup>
+« TITRE I<sup>er</sup>
 
-« AUTRES SERVICES
+« AUTRES SERVICES
 
-« Art. L. 100. – I. – Sans préjudice de l’article L. 112‑15 du code des relations entre le public et l’administration, l’envoi recommandé électronique bénéficie des mêmes effets juridiques que l’envoi recommandé mentionné à l’article L. 1 du présent code, lorsqu’il satisfait aux conditions suivantes :
+« Art. L. 100. – I. – Sans préjudice de l’article L. 112‑15 du code des relations entre le public
+Et l’administration, l’envoi recommandé électronique bénéficie des mêmes effets juridiques que
+L’envoi recommandé mentionné à l’article L. 1 du présent code, lorsqu’il satisfait aux conditions
+Suivantes :
 
-« 1° Il est distribué par un prestataire dûment reconnu comme prestataire de service de confiance qualifié pour les services d’envoi recommandé électronique au sens du règlement (UE) n° 910/2014 du Parlement européen et du Conseil du 23 juillet 2014 sur l’identification électronique et les services de confiance pour les transactions électroniques au sein du marché intérieur et abrogeant la directive 1999/93/CE ;
+« 1° Il est distribué par un prestataire dûment reconnu comme prestataire de service de confiance
+Qualifié pour les services d’envoi recommandé électronique au sens du règlement (UE) n° 910/2014 du
+Parlement européen et du Conseil du 23 juillet 2014 sur l’identification électronique et les
+Services de confiance pour les transactions électroniques au sein du marché intérieur et abrogeant
+La directive 1999/93/CE ;
 
-« 1° bis (nouveau) Le prestataire informe de manière claire, transparente et loyale les consommateurs sur la reconnaissance en tant que prestataire de service de confiance qualifié pour les services d’envoi recommandé au sens du même règlement ;
+« 1° bis (nouveau) Le prestataire informe de manière claire, transparente et loyale les
+Consommateurs sur la reconnaissance en tant que prestataire de service de confiance qualifié pour
+Les services d’envoi recommandé au sens du même règlement ;
 
-« 2° Le procédé électronique utilisé permet d’identifier le prestataire, de désigner l’expéditeur, de garantir l’identité du destinataire et d’établir si l’envoi a été remis ou non au destinataire. Le destinataire doit donner son accord exprès pour l’utilisation d’un tel procédé ;
+« 2° Le procédé électronique utilisé permet d’identifier le prestataire, de désigner l’expéditeur,
+De garantir l’identité du destinataire et d’établir si l’envoi a été remis ou non au destinataire.
+Le destinataire doit donner son accord exprès pour l’utilisation d’un tel procédé ;
 
-« 3° (nouveau) Le procédé permet d’adresser un avis de réception à l’expéditeur, par voie électronique ou par tout autre dispositif lui permettant de le conserver.
+« 3° (nouveau) Le procédé permet d’adresser un avis de réception à l’expéditeur, par voie
+électronique ou par tout autre dispositif lui permettant de le conserver.
 
-« Un décret en Conseil d’État précise les conditions et les modalités d’application des 1° à 3°, conformément au règlement (UE) n° 910/2014 du 23 juillet 2014 précité.
+« Un décret en Conseil d’État précise les conditions et les modalités d’application des 1° à 3°,
+Conformément au règlement (UE) n° 910/2014 du 23 juillet 2014 précité.
 
-« II. – La responsabilité des prestataires de services d’envoi de recommandé électronique est engagée dans les conditions prévues aux articles 1134 et suivants et 1382 et suivants du code civil à raison des retards, pertes et avaries survenues lors de la prestation, selon des modalités fixées par un décret en Conseil d’État qui détermine des plafonds d’indemnisation.
+« II. – La responsabilité des prestataires de services d’envoi de recommandé électronique est
+Engagée dans les conditions prévues aux articles 1134 et suivants et 1382 et suivants du code civil
+à raison des retards, pertes et avaries survenues lors de la prestation, selon des modalités fixées
+Par un décret en Conseil d’État qui détermine des plafonds d’indemnisation.
 
-« III. – L’Autorité de régulation des communications électroniques et des postes veille au respect, par les prestataires de services d’envoi de recommandé électronique, des obligations législatives et réglementaires afférentes à la prestation de services d’envoi de recommandé électronique. Elle sanctionne les manquements constatés dans les conditions prévues à l’article L. 36‑11 du présent code. »
+« III. – L’Autorité de régulation des communications électroniques et des postes veille au respect,
+Par les prestataires de services d’envoi de recommandé électronique, des obligations législatives et
+Réglementaires afférentes à la prestation de services d’envoi de recommandé électronique. Elle
+Sanctionne les manquements constatés dans les conditions prévues à l’article L. 36‑11 du présent
+Code. »
 
-II. – L’article L. 36‑11 du même code est ainsi modifié :
+II. – L’article L. 36‑11 du même code est ainsi modifié :
 
-1°  et 2° (Supprimés)
+1° et 2° (Supprimés)
 
-3° Au cinquième alinéa du même I, après les mots : « l’exploitant » sont insérés les mots : « , le prestataire » ;
+3° Au cinquième alinéa du même I, après les mots : « l’exploitant » sont insérés les mots : « , le
+Prestataire » ;
 
-4° À la première phrase du II, tel qu’il résulte de l’article 19 de la présente loi, après le mot : « ligne », sont insérés les mots : « ou un prestataire de services d’envoi de recommandé électronique » ;
+4° À la première phrase du II, tel qu’il résulte de l’article 19 de la présente loi, après le mot
+: « ligne », sont insérés les mots : « ou un prestataire de services d’envoi de recommandé
+électronique » ;
 
-5° Au quatrième alinéa du III, après les mots : « service de communications électroniques », sont insérés les mots : « ou une prestation de services d’envoi de recommandé électronique » ;
+5° Au quatrième alinéa du III, après les mots : « service de communications électroniques », sont
+Insérés les mots : « ou une prestation de services d’envoi de recommandé électronique » ;
 
-6° Au VII, après le mot : « opérateur », sont insérés les mots : « , pour un prestataire de services d’envoi de recommandé électronique ».
+6° Au VII, après le mot : « opérateur », sont insérés les mots : « , pour un prestataire de
+Services d’envoi de recommandé électronique ».
 
 Section 2
 
 Paiement par facturation
-de l’opérateur de communications électroniques
+De l’opérateur de communications électroniques
 
 Article 41
 
-I. – Le code monétaire et financier est ainsi modifié :
+I. – Le code monétaire et financier est ainsi modifié :
 
-1° Après l’article L. 521‑3, il est inséré un article L. 521‑3‑1 ainsi rédigé :
+1° Après l’article L. 521‑3, il est inséré un article L. 521‑3‑1 ainsi rédigé :
 
-« Art. L. 521‑3‑1. – I. – Par exception à l’interdiction prévue à l’article L. 521‑2, un fournisseur de réseaux ou de services de communications électroniques peut fournir des services de paiement, en sus des services de communications électroniques, à un abonné à ce réseau ou à ce service, pour l’exécution :
+« Art. L. 521‑3‑1. – I. – Par exception à l’interdiction prévue à l’article L. 521‑2, un
+Fournisseur de réseaux ou de services de communications électroniques peut fournir des services de
+Paiement, en sus des services de communications électroniques, à un abonné à ce réseau ou à ce
+Service, pour l’exécution :
 
-« 1° D’opérations de paiement effectuées pour l’achat de contenus numériques et de services vocaux, quel que soit le dispositif utilisé pour l’achat ou la consommation de ces contenus numériques, et imputées sur la facture correspondante ;
+« 1° D’opérations de paiement effectuées pour l’achat de contenus numériques et de services vocaux,
+Quel que soit le dispositif utilisé pour l’achat ou la consommation de ces contenus numériques, et
+Imputées sur la facture correspondante ;
 
-« 2° D’opérations de paiement exécutées depuis un dispositif électronique ou au moyen de celui‑ci et imputées sur la facture correspondante, dans le cadre de la collecte de dons par les organismes faisant appel public à la générosité au sens de la loi n° 91‑772 du 7 août 1991 relative au congé de représentation en faveur des associations et des mutuelles et au contrôle des comptes des organismes faisant appel à la générosité publique ;
+« 2° D’opérations de paiement exécutées depuis un dispositif électronique ou au moyen de celui‑ci
+Et imputées sur la facture correspondante, dans le cadre de la collecte de dons par les organismes
+Faisant appel public à la générosité au sens de la loi n° 91‑772 du 7 août 1991 relative au congé de
+Représentation en faveur des associations et des mutuelles et au contrôle des comptes des organismes
+Faisant appel à la générosité publique ;
 
-« 3° D’opérations de paiement exécutées depuis un dispositif électronique ou au moyen de celui‑ci et imputées sur la facture correspondante pour l’achat de tickets électroniques.
+« 3° D’opérations de paiement exécutées depuis un dispositif électronique ou au moyen de celui‑ci
+Et imputées sur la facture correspondante pour l’achat de tickets électroniques.
 
-« La valeur de chaque opération de paiement isolée et la valeur mensuelle cumulée des opérations de paiement pour un même abonné ne peuvent pas excéder, respectivement, les montants de 50 € et de 300 €.
+« La valeur de chaque opération de paiement isolée et la valeur mensuelle cumulée des opérations de
+Paiement pour un même abonné ne peuvent pas excéder, respectivement, les montants de 50 € et de 300
+€.
 
-« Le présent I s’applique également lorsqu’un abonné préfinance son compte auprès du fournisseur de réseaux ou de services de communications électroniques.
+« Le présent I s’applique également lorsqu’un abonné préfinance son compte auprès du fournisseur
+De réseaux ou de services de communications électroniques.
 
-« II. – Avant de commencer à exercer les activités mentionnées au I, le fournisseur de réseaux ou de services de communications électroniques adresse une déclaration à l’Autorité de contrôle prudentiel et de résolution, qui dispose d’un délai fixé par décret en Conseil d’État à compter de la réception de toutes les informations nécessaires pour notifier au déclarant que les conditions mentionnées au même I ne sont pas remplies.
+« II. – Avant de commencer à exercer les activités mentionnées au I, le fournisseur de réseaux ou
+De services de communications électroniques adresse une déclaration à l’Autorité de contrôle
+Prudentiel et de résolution, qui dispose d’un délai fixé par décret en Conseil d’État à compter de
+La réception de toutes les informations nécessaires pour notifier au déclarant que les conditions
+Mentionnées au même I ne sont pas remplies.
 
-« Le fournisseur de réseaux ou de services de communications électroniques adresse à l’Autorité de contrôle prudentiel et de résolution un rapport annuel justifiant du respect des conditions mentionnées audit I.
+« Le fournisseur de réseaux ou de services de communications électroniques adresse à l’Autorité de
+Contrôle prudentiel et de résolution un rapport annuel justifiant du respect des conditions
+Mentionnées audit I.
 
-« Dès que le fournisseur de réseaux ou de services de communications électroniques prévoit de ne plus remplir les conditions mentionnées au même I, il dépose une demande d’agrément auprès de l’Autorité de contrôle prudentiel et de résolution en application de l’article L. 522‑6.
+« Dès que le fournisseur de réseaux ou de services de communications électroniques prévoit de ne
+Plus remplir les conditions mentionnées au même I, il dépose une demande d’agrément auprès de
+L’Autorité de contrôle prudentiel et de résolution en application de l’article L. 522‑6.
 
-« Lorsque l’Autorité de contrôle prudentiel et de résolution notifie à un fournisseur de réseaux ou de services de communications électroniques que les conditions mentionnées au I du présent article ne sont plus remplies, il dispose d’un délai de trois mois pour prendre les mesures nécessaires pour respecter ces conditions ou pour déposer une demande d’agrément auprès de l’Autorité de contrôle prudentiel et de résolution en application de l’article L. 522‑6.
+« Lorsque l’Autorité de contrôle prudentiel et de résolution notifie à un fournisseur de réseaux ou
+De services de communications électroniques que les conditions mentionnées au I du présent article
+Ne sont plus remplies, il dispose d’un délai de trois mois pour prendre les mesures nécessaires pour
+Respecter ces conditions ou pour déposer une demande d’agrément auprès de l’Autorité de contrôle
+Prudentiel et de résolution en application de l’article L. 522‑6.
 
-« Tant que l’Autorité de contrôle prudentiel et de résolution ne s’est pas prononcée sur l’octroi de l’agrément, le fournisseur de réseaux ou de services de communications électroniques veille à respecter les conditions prévues au I du présent article. » ;
+« Tant que l’Autorité de contrôle prudentiel et de résolution ne s’est pas prononcée sur l’octroi
+De l’agrément, le fournisseur de réseaux ou de services de communications électroniques veille à
+Respecter les conditions prévues au I du présent article. » ;
 
-2° Après l’article L. 525‑6, il est inséré un article L. 525‑6‑1 ainsi rédigé :
+2° Après l’article L. 525‑6, il est inséré un article L. 525‑6‑1 ainsi rédigé :
 
-« Art. L. 525‑6‑1. – I. – Par dérogation à l’article L. 525‑3, un fournisseur de réseaux ou de services de communications électroniques peut émettre et gérer de la monnaie électronique, en sus des services de communications électroniques pour un abonné au réseau ou au service, pour l’exécution :
+« Art. L. 525‑6‑1. – I. – Par dérogation à l’article L. 525‑3, un fournisseur de réseaux ou de
+Services de communications électroniques peut émettre et gérer de la monnaie électronique, en sus
+Des services de communications électroniques pour un abonné au réseau ou au service, pour
+L’exécution :
 
-« 1° D’opérations de paiement effectuées pour l’achat de contenus numériques et de services vocaux, quel que soit le dispositif utilisé pour l’achat ou la consommation de ces contenus numériques, et imputées sur la facture correspondante ;
+« 1° D’opérations de paiement effectuées pour l’achat de contenus numériques et de services vocaux,
+Quel que soit le dispositif utilisé pour l’achat ou la consommation de ces contenus numériques, et
+Imputées sur la facture correspondante ;
 
-« 2° D’opérations de paiement exécutées depuis un dispositif électronique ou au moyen de celui‑ci et imputées sur la facture correspondante, dans le cadre de la collecte de dons par les organismes faisant appel public à la générosité, au sens de la loi n° 91‑772 du 7 août 1991 relative au congé de représentation en faveur des associations et des mutuelles et au contrôle des comptes des organismes faisant appel à la générosité publique ;
+« 2° D’opérations de paiement exécutées depuis un dispositif électronique ou au moyen de celui‑ci
+Et imputées sur la facture correspondante, dans le cadre de la collecte de dons par les organismes
+Faisant appel public à la générosité, au sens de la loi n° 91‑772 du 7 août 1991 relative au congé
+De représentation en faveur des associations et des mutuelles et au contrôle des comptes des
+Organismes faisant appel à la générosité publique ;
 
-« 3° D’opérations de paiement exécutées depuis un dispositif électronique ou au moyen de celui‑ci et imputées sur la facture correspondante pour l’achat de tickets électroniques.
+« 3° D’opérations de paiement exécutées depuis un dispositif électronique ou au moyen de celui‑ci
+Et imputées sur la facture correspondante pour l’achat de tickets électroniques.
 
-« La valeur de chaque opération de paiement isolée et la valeur mensuelle cumulée des opérations de paiement pour un même abonné ne peuvent pas excéder, respectivement, les montants de 50 € et de 300 €.
+« La valeur de chaque opération de paiement isolée et la valeur mensuelle cumulée des opérations de
+Paiement pour un même abonné ne peuvent pas excéder, respectivement, les montants de 50 € et de 300
+€.
 
-« Le présent I s’applique également lorsqu’un abonné préfinance son compte auprès du fournisseur de réseaux ou de services de communications électroniques.
+« Le présent I s’applique également lorsqu’un abonné préfinance son compte auprès du fournisseur
+De réseaux ou de services de communications électroniques.
 
-« II. – Avant de commencer à exercer les activités mentionnées au I, le fournisseur de réseaux ou de services de communications électroniques adresse une déclaration à l’Autorité de contrôle prudentiel et de résolution, qui dispose d’un délai fixé par décret en Conseil d’État à compter de la réception de toutes les informations nécessaires pour notifier au déclarant que les conditions mentionnées au même I ne sont pas remplies.
+« II. – Avant de commencer à exercer les activités mentionnées au I, le fournisseur de réseaux ou
+De services de communications électroniques adresse une déclaration à l’Autorité de contrôle
+Prudentiel et de résolution, qui dispose d’un délai fixé par décret en Conseil d’État à compter de
+La réception de toutes les informations nécessaires pour notifier au déclarant que les conditions
+Mentionnées au même I ne sont pas remplies.
 
-« Le fournisseur de réseaux ou de services de communications électroniques adresse à l’Autorité de contrôle prudentiel et de résolution un rapport annuel justifiant du respect des conditions mentionnées audit I.
+« Le fournisseur de réseaux ou de services de communications électroniques adresse à l’Autorité de
+Contrôle prudentiel et de résolution un rapport annuel justifiant du respect des conditions
+Mentionnées audit I.
 
-« Dès que le fournisseur de réseaux ou de services de communications électroniques prévoit de ne plus remplir les conditions mentionnées au même I, il dépose une demande d’agrément auprès de l’Autorité de contrôle prudentiel et de résolution en application de l’article L. 526‑7.
+« Dès que le fournisseur de réseaux ou de services de communications électroniques prévoit de ne
+Plus remplir les conditions mentionnées au même I, il dépose une demande d’agrément auprès de
+L’Autorité de contrôle prudentiel et de résolution en application de l’article L. 526‑7.
 
-« Lorsque l’Autorité de contrôle prudentiel et de résolution notifie à un fournisseur de réseaux ou de services de communications électroniques que les conditions mentionnées au I du présent article ne sont plus remplies, il dispose d’un délai de trois mois pour prendre les mesures nécessaires pour respecter ces conditions précitées ou pour déposer une demande d’agrément auprès de l’Autorité de contrôle prudentiel et de résolution en application de l’article L. 526‑7.
+« Lorsque l’Autorité de contrôle prudentiel et de résolution notifie à un fournisseur de réseaux ou
+De services de communications électroniques que les conditions mentionnées au I du présent article
+Ne sont plus remplies, il dispose d’un délai de trois mois pour prendre les mesures nécessaires pour
+Respecter ces conditions précitées ou pour déposer une demande d’agrément auprès de l’Autorité de
+Contrôle prudentiel et de résolution en application de l’article L. 526‑7.
 
-« Tant que l’Autorité de contrôle prudentiel et de résolution ne s’est pas prononcée sur l’octroi de l’agrément, le fournisseur de réseaux ou de services de communications électroniques veille à respecter les conditions prévues au I du présent article. » ;
+« Tant que l’Autorité de contrôle prudentiel et de résolution ne s’est pas prononcée sur l’octroi
+De l’agrément, le fournisseur de réseaux ou de services de communications électroniques veille à
+Respecter les conditions prévues au I du présent article. » ;
 
-3° Le 1° de l’article L. 311‑4 est abrogé ;
+3° Le 1° de l’article L. 311‑4 est abrogé ;
 
-4° Au premier alinéa, à la première phrase du deuxième alinéa et aux trois derniers alinéas du II de l’article L. 521‑3 et aux deux premiers alinéas et aux trois derniers alinéas de l’article L. 525‑6, la référence : « ou au 1° de l’article L. 311‑4 » est supprimée ;
+4° Au premier alinéa, à la première phrase du deuxième alinéa et aux trois derniers alinéas du II
+De l’article L. 521‑3 et aux deux premiers alinéas et aux trois derniers alinéas de l’article L.
+525‑6, la référence : « ou au 1° de l’article L. 311‑4 » est supprimée ;
 
-5° (nouveau) Au second alinéa de l’article L. 526‑11, la référence : « ou du 1° de l’article L. 311‑4 » est supprimée.
+5° (nouveau) Au second alinéa de l’article L. 526‑11, la référence : « ou du 1° de l’article L.
+311‑4 » est supprimée.
 
-II. – La date d’entrée en vigueur du présent article est fixée par décret conformément aux articles 115 et 116 de la directive 2015/2366/UE du Parlement européen et du Conseil du 25 novembre 2015 concernant les services de paiement dans le marché intérieur et modifiant les directives 2002/65/CE, 2013/36/UE et le règlement (UE) n° 1099/2010 et abrogeant la directive 2007/64/CE.
+II. – La date d’entrée en vigueur du présent article est fixée par décret conformément aux
+Articles 115 et 116 de la directive 2015/2366/UE du Parlement européen et du Conseil du 25 novembre
+2015 concernant les services de paiement dans le marché intérieur et modifiant les directives
+2002/65/CE, 2013/36/UE et le règlement (UE) n° 1099/2010 et abrogeant la directive 2007/64/CE.
 
 Section 3
 
@@ -129,23 +221,36 @@ Compétitions de jeux vidéo
 
 Article 42
 
-I. – Un agrément peut être délivré par le ministre chargé de la jeunesse aux organisateurs de compétitions de jeux vidéo, notamment à dominante sportive, requérant la présence physique des joueurs, qui présentent des garanties visant à :
+I. – Un agrément peut être délivré par le ministre chargé de la jeunesse aux organisateurs de
+Compétitions de jeux vidéo, notamment à dominante sportive, requérant la présence physique des
+Joueurs, qui présentent des garanties visant à :
 
-1° Assurer l’intégrité, la fiabilité et la transparence des compétitions ;
+1° Assurer l’intégrité, la fiabilité et la transparence des compétitions ;
 
-2° Protéger les mineurs ;
+2° Protéger les mineurs ;
 
-3° Prévenir les activités frauduleuses ou criminelles ;
+3° Prévenir les activités frauduleuses ou criminelles ;
 
-4° Prévenir les atteintes à la santé publique.
+4° Prévenir les atteintes à la santé publique.
 
-II. – Un arrêté du ministre chargé de la jeunesse fixe la liste des logiciels de loisirs, sur un support physique ou en ligne, s’appuyant sur une trame scénarisée ou des situations simulées, pour lesquels les organisateurs de compétitions peuvent bénéficier de l’agrément prévu au I du présent article.
+II. – Un arrêté du ministre chargé de la jeunesse fixe la liste des logiciels de loisirs, sur un
+Support physique ou en ligne, s’appuyant sur une trame scénarisée ou des situations simulées, pour
+Lesquels les organisateurs de compétitions peuvent bénéficier de l’agrément prévu au I du présent
+Article.
 
-Ces logiciels de loisirs font prédominer, dans l’issue de la compétition, les combinaisons de l’intelligence et l’habilité des joueurs, en mettant à leur disposition des commandes et des interactions se traduisant sous formes d’images animées, sonorisées ou non, et visant à la recherche de performances physiques virtuelles ou intellectuelles.
+Ces logiciels de loisirs font prédominer, dans l’issue de la compétition, les combinaisons de
+L’intelligence et l’habilité des joueurs, en mettant à leur disposition des commandes et des
+Interactions se traduisant sous formes d’images animées, sonorisées ou non, et visant à la recherche
+De performances physiques virtuelles ou intellectuelles.
 
-L’arrêté fixe également, pour chaque logiciel de loisir, l’âge minimal requis des joueurs pour participer à la compétition.
+L’arrêté fixe également, pour chaque logiciel de loisir, l’âge minimal requis des joueurs pour
+Participer à la compétition.
 
-III. – Les compétitions pour lesquelles les organisateurs bénéficient de l’agrément prévu au I du présent article ne sont pas soumises aux articles L. 322‑1 à L. 322‑2‑1 du code de la sécurité intérieure.
+III. – Les compétitions pour lesquelles les organisateurs bénéficient de l’agrément prévu au I du
+Présent article ne sont pas soumises aux articles L. 322‑1 à L. 322‑2‑1 du code de la sécurité
+Intérieure.
 
-Il en est de même des phases de qualifications de ces compétitions se déroulant en ligne, dès lors qu’aucun sacrifice financier de nature à accroître l’espérance de gain du joueur ou de son équipe n’est exigé par l’organisateur.
+Il en est de même des phases de qualifications de ces compétitions se déroulant en ligne, dès lors
+Qu’aucun sacrifice financier de nature à accroître l’espérance de gain du joueur ou de son équipe
+N’est exigé par l’organisateur.
 

--- a/Titre III/Chapitre III - Accès des publics fragiles au numérique.md
+++ b/Titre III/Chapitre III - Accès des publics fragiles au numérique.md
@@ -1,12 +1,12 @@
-Chapitre III
+## Chapitre III
 
 Accès des publics fragiles au numérique
 
-Section 1
+### Section 1
 
 Accès des personnes handicapées aux services téléphoniques
 
-Article 43
+#### Article 43
 
 I. – L’article 78 de la loi n° 2005‑102 du 11 février 2005 sur l’égalité des droits et des
 Chances, la participation et la citoyenneté des personnes handicapées est ainsi modifié :
@@ -72,11 +72,11 @@ Décret, et au plus tard cinq ans après la promulgation de la présente loi. Le
 Une date fixée par décret, et au plus tard deux ans après la promulgation de la présente loi. Le
 Décret précise également les modalités de suivi de l’application du présent article.
 
-Section 2
+### Section 2
 
 Accès des personnes handicapées aux sites internet publics
 
-Article 44
+#### Article 44
 
 I. – L’article 47 de la loi n° 2005‑102 du 11 février 2005 précitée est ainsi rédigé :
 
@@ -124,11 +124,11 @@ Participation et la citoyenneté des personnes handicapées. » ;
 2° L’avant-dernier alinéa est complété par les mots : « ainsi qu’à l’article 47 de la loi n°
 2005‑102 du 11 février 2005 précitée. »
 
-Section 3
+### Section 3
 
 Maintien de la connexion à internet
 
-Article 45
+#### Article 45
 
 I. – L’article L. 115‑3 du code de l’action sociale et des familles est ainsi modifié :
 
@@ -160,7 +160,7 @@ Par les mots : « , de services téléphoniques ou de services d’accès à int
 3° (nouveau) Au deuxième alinéa de l’article 6‑3, après le mot : « eau », sont insérés les mots :
 « ou de services téléphoniques ou d’accès à internet ».
 
-Article 45 bis (nouveau)
+#### Article 45 bis (nouveau)
 
 Le code du travail est ainsi modifié :
 
@@ -170,13 +170,13 @@ Le code du travail est ainsi modifié :
 2° Le troisième alinéa de l’article L. 6321‑1 est complété par les mots : « et l’illettrisme
 Numérique ».
 
-Chapitre IV
+## Chapitre IV
 
 Accès des personnes détenues à internet
 
 (Division et intitulé nouveaux)
 
-Article 45 ter (nouveau)
+#### Article 45 ter (nouveau)
 
 Il est remis au Parlement, avant le 1<sup>er</sup> janvier 2017, un rapport sur les conditions et
 Les modalités de mise en œuvre de l’accès au numérique de toutes les personnes privées de liberté.

--- a/Titre III/Chapitre III - Accès des publics fragiles au numérique.md
+++ b/Titre III/Chapitre III - Accès des publics fragiles au numérique.md
@@ -8,33 +8,69 @@ Accès des personnes handicapées aux services téléphoniques
 
 Article 43
 
-I. – L’article 78 de la loi n° 2005‑102 du 11 février 2005 sur l’égalité des droits et des chances, la participation et la citoyenneté des personnes handicapées est ainsi modifié :
+I. – L’article 78 de la loi n° 2005‑102 du 11 février 2005 sur l’égalité des droits et des
+Chances, la participation et la citoyenneté des personnes handicapées est ainsi modifié :
 
-1° (nouveau) Le premier alinéa est ainsi modifié :
+1° (nouveau) Le premier alinéa est ainsi modifié :
 
-a) Les mots : « déficientes auditives » sont remplacés par les mots : « sourdes et malentendantes » ;
+A) Les mots : « déficientes auditives » sont remplacés par les mots : « sourdes et malentendantes
+» ;
 
-b) Les mots : « écrite simultanée » sont remplacés par les mots : « simultanée écrite » ;
+B) Les mots : « écrite simultanée » sont remplacés par les mots : « simultanée écrite » ;
 
-2° Après le même alinéa, il est inséré un alinéa ainsi rédigé :
+2° Après le même alinéa, il est inséré un alinéa ainsi rédigé :
 
-« Les services d’accueil téléphonique destinés à recevoir les appels des usagers sont accessibles aux personnes sourdes et malentendantes par la mise à disposition d’un service de traduction écrite simultanée et visuelle. Les numéros de téléphones concernés sont accessibles directement ou, à défaut, par l’intermédiaire d’une plateforme en ligne dédiée délivrant le service de traduction écrite et visuelle. L’accessibilité est soit assurée directement par le service public, soit confiée par le service public, sous sa responsabilité, à un opérateur spécialisé qui en assure la mise en œuvre et l’exécution. » ;
+« Les services d’accueil téléphonique destinés à recevoir les appels des usagers sont accessibles
+Aux personnes sourdes et malentendantes par la mise à disposition d’un service de traduction écrite
+Simultanée et visuelle. Les numéros de téléphones concernés sont accessibles directement ou, à
+Défaut, par l’intermédiaire d’une plateforme en ligne dédiée délivrant le service de traduction
+écrite et visuelle. L’accessibilité est soit assurée directement par le service public, soit confiée
+Par le service public, sous sa responsabilité, à un opérateur spécialisé qui en assure la mise en
+œuvre et l’exécution. » ;
 
-3° (nouveau) Après le deuxième alinéa, il est inséré un alinéa ainsi rédigé :
+3° (nouveau) Après le deuxième alinéa, il est inséré un alinéa ainsi rédigé :
 
-« Le service de traduction ou le dispositif de communication adapté mentionnés aux trois premiers alinéas garantissent le respect de la confidentialité des conversations traduites ou transcrites. »
+« Le service de traduction ou le dispositif de communication adapté mentionnés aux trois premiers
+Alinéas garantissent le respect de la confidentialité des conversations traduites ou transcrites. »
 
-II. – L’article L. 113‑5 du code de la consommation est complété par un alinéa ainsi rédigé :
+II. – L’article L. 113‑5 du code de la consommation est complété par un alinéa ainsi rédigé :
 
-« Les acteurs économiques du secteur privé qui vendent, offrent ou proposent directement aux consommateurs ou aux bénéficiaires des biens et des services rendent accessibles leurs services d’accueil téléphonique aux personnes sourdes et malentendantes par la mise à disposition d’un service de traduction écrite simultanée et visuelle. Les numéros de téléphone concernés sont accessibles directement ou, à défaut, par l’intermédiaire d’une plateforme en ligne dédiée délivrant le service de traduction écrite et visuelle. L’accessibilité est soit assurée directement par l’acteur économique, soit confiée par l’acteur économique, sous sa responsabilité, à un opérateur spécialisé qui en assure la mise en œuvre et l’exécution. Un décret précise les modalités d’application dans le temps du présent alinéa sachant qu’il ne peut prévoir la mise en place de ce dispositif au delà de cinq années après la promulgation de la loi n°     du      pour une République numérique. »
+« Les acteurs économiques du secteur privé qui vendent, offrent ou proposent directement aux
+Consommateurs ou aux bénéficiaires des biens et des services rendent accessibles leurs services
+D’accueil téléphonique aux personnes sourdes et malentendantes par la mise à disposition d’un
+Service de traduction écrite simultanée et visuelle. Les numéros de téléphone concernés sont
+Accessibles directement ou, à défaut, par l’intermédiaire d’une plateforme en ligne dédiée délivrant
+Le service de traduction écrite et visuelle. L’accessibilité est soit assurée directement par
+L’acteur économique, soit confiée par l’acteur économique, sous sa responsabilité, à un opérateur
+Spécialisé qui en assure la mise en œuvre et l’exécution. Un décret précise les modalités
+D’application dans le temps du présent alinéa sachant qu’il ne peut prévoir la mise en place de ce
+Dispositif au delà de cinq années après la promulgation de la loi n° du pour une République
+Numérique. »
 
-III. – Après le o du I de l’article L. 33‑1 du code des postes et des communications électroniques, il est inséré un p ainsi rédigé :
+III. – Après le o du I de l’article L. 33‑1 du code des postes et des communications
+électroniques, il est inséré un p ainsi rédigé :
 
-« p) Un accès des utilisateurs finals sourds et malentendants à une offre de services de communications électroniques, incluant la fourniture, à un prix abordable au sens de l’article L. 35‑1 et dans le respect de conditions de qualité définies par l’Autorité de régulation des communications électroniques et des postes, d’un service de traduction simultanée écrite et visuelle. Ce service garantit les conditions de neutralité et de confidentialité mentionnées au b du présent I ainsi que la prévention de la violation des données à caractère personnel mentionnée à l’article 34 bis de la loi n° 78‑17 du 6 janvier 1978 relative à l’informatique, aux fichiers et aux libertés ; ».
+« p) Un accès des utilisateurs finals sourds et malentendants à une offre de services de
+Communications électroniques, incluant la fourniture, à un prix abordable au sens de l’article L.
+35‑1 et dans le respect de conditions de qualité définies par l’Autorité de régulation des
+Communications électroniques et des postes, d’un service de traduction simultanée écrite et
+Visuelle. Ce service garantit les conditions de neutralité et de confidentialité mentionnées au b du
+Présent I ainsi que la prévention de la violation des données à caractère personnel mentionnée à
+L’article 34 bis de la loi n° 78‑17 du 6 janvier 1978 relative à l’informatique, aux fichiers et aux
+Libertés ; ».
 
-III bis (nouveau). – La mise en œuvre des I à III peut s’appuyer sur des applications de communications électroniques permettant la vocalisation du texte, la transcription de la voix en texte, la traduction en et depuis la langue française de signes ou la transcription en et depuis le langage parlé complété. Cette mise en œuvre ne peut se substituer au service de traduction simultanée écrite et visuelle mentionné aux mêmes I à III qu’à la condition de garantir une accessibilité de qualité équivalente et d’offrir les mêmes conditions de traduction à toutes les personnes sourdes et malentendantes.
+III bis (nouveau). – La mise en œuvre des I à III peut s’appuyer sur des applications de
+Communications électroniques permettant la vocalisation du texte, la transcription de la voix en
+Texte, la traduction en et depuis la langue française de signes ou la transcription en et depuis le
+Langage parlé complété. Cette mise en œuvre ne peut se substituer au service de traduction
+Simultanée écrite et visuelle mentionné aux mêmes I à III qu’à la condition de garantir une
+Accessibilité de qualité équivalente et d’offrir les mêmes conditions de traduction à toutes les
+Personnes sourdes et malentendantes.
 
-IV. – Le 2° du I et le III entrent en vigueur selon des modalités et à une date prévues par décret, et au plus tard cinq ans après la promulgation de la présente loi. Le II entre en vigueur à une date fixée par décret, et au plus tard deux ans après la promulgation de la présente loi. Le décret précise également les modalités de suivi de l’application du présent article.
+IV. – Le 2° du I et le III entrent en vigueur selon des modalités et à une date prévues par
+Décret, et au plus tard cinq ans après la promulgation de la présente loi. Le II entre en vigueur à
+Une date fixée par décret, et au plus tard deux ans après la promulgation de la présente loi. Le
+Décret précise également les modalités de suivi de l’application du présent article.
 
 Section 2
 
@@ -42,27 +78,51 @@ Accès des personnes handicapées aux sites internet publics
 
 Article 44
 
-I. – L’article 47 de la loi n° 2005‑102 du 11 février 2005 précitée est ainsi rédigé :
+I. – L’article 47 de la loi n° 2005‑102 du 11 février 2005 précitée est ainsi rédigé :
 
-« Art. 47. – I. – Les services de communication publique en ligne des services de l’État, des collectivités territoriales et des établissements publics qui en dépendent ainsi que des organismes délégataires d’une mission de service public doivent être accessibles aux personnes handicapées.
+« Art. 47. – I. – Les services de communication publique en ligne des services de l’État, des
+Collectivités territoriales et des établissements publics qui en dépendent ainsi que des organismes
+Délégataires d’une mission de service public doivent être accessibles aux personnes handicapées.
 
-« L’accessibilité des services de communication publique en ligne concerne l’accès à tout type d’information sous forme numérique, quels que soient le moyen d’accès, les contenus et le mode de consultation. Les recommandations internationales pour l’accessibilité de l’internet doivent être appliquées pour les services de communication publique en ligne.
+« L’accessibilité des services de communication publique en ligne concerne l’accès à tout type
+D’information sous forme numérique, quels que soient le moyen d’accès, les contenus et le mode de
+Consultation. Les recommandations internationales pour l’accessibilité de l’internet doivent être
+Appliquées pour les services de communication publique en ligne.
 
-« Les personnes mentionnées au premier alinéa élaborent un schéma pluriannuel de mise en accessibilité de leurs services de communication publique en ligne qui est rendu public et décliné en plans d’action annuels.
+« Les personnes mentionnées au premier alinéa élaborent un schéma pluriannuel de mise en
+Accessibilité de leurs services de communication publique en ligne qui est rendu public et décliné
+En plans d’action annuels.
 
-« II. – La page d’accueil de tout service de communication publique en ligne comporte une mention clairement visible précisant s’il est ou non conforme aux règles relatives à l’accessibilité ainsi qu’un lien renvoyant à une page indiquant notamment l’état de mise en œuvre du schéma pluriannuel de mise en accessibilité et du plan d’action de l’année en cours mentionnés au I et permettant aux usagers de signaler les manquements aux règles d’accessibilité de ce service.
+« II. – La page d’accueil de tout service de communication publique en ligne comporte une mention
+Clairement visible précisant s’il est ou non conforme aux règles relatives à l’accessibilité ainsi
+Qu’un lien renvoyant à une page indiquant notamment l’état de mise en œuvre du schéma pluriannuel de
+Mise en accessibilité et du plan d’action de l’année en cours mentionnés au I et permettant aux
+Usagers de signaler les manquements aux règles d’accessibilité de ce service.
 
-« III. – Le défaut de mise en conformité d’un service de communication publique en ligne avec les obligations prévues au II fait l’objet d’une sanction administrative dont le montant, ne pouvant excéder 5 000 €, est fixé par le décret en Conseil d’État mentionné au IV. Une nouvelle sanction est prononcée chaque année lorsque le manquement à ces dispositions perdure.
+« III. – Le défaut de mise en conformité d’un service de communication publique en ligne avec les
+Obligations prévues au II fait l’objet d’une sanction administrative dont le montant, ne pouvant
+Excéder 5 000 €, est fixé par le décret en Conseil d’État mentionné au IV. Une nouvelle sanction est
+Prononcée chaque année lorsque le manquement à ces dispositions perdure.
 
-« IV. – Un décret en Conseil d’État fixe les règles relatives à l’accessibilité et précise, par référence aux recommandations établies par l’autorité administrative compétente, la nature des adaptations à mettre en œuvre ainsi que les délais de mise en conformité des services de communication publique en ligne existants, qui ne peuvent excéder trois ans, et les conditions dans lesquelles des sanctions sont imposées et recouvrées en cas de non‑respect des obligations prévues au II. Ce décret définit les modalités de formation des personnels intervenant sur les services de communication publique en ligne. »
+« IV. – Un décret en Conseil d’État fixe les règles relatives à l’accessibilité et précise, par
+Référence aux recommandations établies par l’autorité administrative compétente, la nature des
+Adaptations à mettre en œuvre ainsi que les délais de mise en conformité des services de
+Communication publique en ligne existants, qui ne peuvent excéder trois ans, et les conditions dans
+Lesquelles des sanctions sont imposées et recouvrées en cas de non‑respect des obligations prévues
+Au II. Ce décret définit les modalités de formation des personnels intervenant sur les services de
+Communication publique en ligne. »
 
-II. – L’article L. 111‑7‑12 du code de la construction et de l’habitation est ainsi modifié :
+II. – L’article L. 111‑7‑12 du code de la construction et de l’habitation est ainsi modifié :
 
-1° Le premier alinéa est complété par une phrase ainsi rédigée :
+1° Le premier alinéa est complété par une phrase ainsi rédigée :
 
-« Ce fonds peut également participer au financement des prestations destinées à assurer le respect de l’obligation d’accessibilité des services de communication au public en ligne, prévue à l’article 47 de la loi n° 2005‑102 du 11 février 2005 pour l’égalité des droits et des chances, la participation et la citoyenneté des personnes handicapées. » ;
+« Ce fonds peut également participer au financement des prestations destinées à assurer le respect
+De l’obligation d’accessibilité des services de communication au public en ligne, prévue à l’article
+47 de la loi n° 2005‑102 du 11 février 2005 pour l’égalité des droits et des chances, la
+Participation et la citoyenneté des personnes handicapées. » ;
 
-2° L’avant-dernier alinéa est complété par les mots : « ainsi qu’à l’article 47 de la loi n° 2005‑102 du 11 février 2005 précitée. »
+2° L’avant-dernier alinéa est complété par les mots : « ainsi qu’à l’article 47 de la loi n°
+2005‑102 du 11 février 2005 précitée. »
 
 Section 3
 
@@ -70,31 +130,45 @@ Maintien de la connexion à internet
 
 Article 45
 
-I. – L’article L. 115‑3 du code de l’action sociale et des familles est ainsi modifié :
+I. – L’article L. 115‑3 du code de l’action sociale et des familles est ainsi modifié :
 
-1° À la fin du premier alinéa, les mots : « et de services téléphoniques dans son logement » sont remplacés par les mots : « d’un service de téléphonie fixe et d’un service d’accès à internet » ;
+1° À la fin du premier alinéa, les mots : « et de services téléphoniques dans son logement » sont
+Remplacés par les mots : « d’un service de téléphonie fixe et d’un service d’accès à internet » ;
 
-2° Le deuxième alinéa est ainsi rédigé :
+2° Le deuxième alinéa est ainsi rédigé :
 
-« En cas de non‑paiement des factures, la fourniture d’énergie et d’eau, un service téléphonique et un service d’accès à internet sont maintenus jusqu’à ce qu’il ait été statué sur la demande d’aide. Le service téléphonique maintenu peut être restreint par l’opérateur sous réserve de préserver la possibilité de recevoir des appels ainsi que de passer des communications locales et vers les numéros gratuits et d’urgence. Le débit du service d’accès à internet maintenu peut être restreint par l’opérateur, sous réserve de préserver un accès fonctionnel aux services de communication au public en ligne et aux services de courrier électronique. » ;
+« En cas de non‑paiement des factures, la fourniture d’énergie et d’eau, un service téléphonique et
+Un service d’accès à internet sont maintenus jusqu’à ce qu’il ait été statué sur la demande d’aide.
+Le service téléphonique maintenu peut être restreint par l’opérateur sous réserve de préserver la
+Possibilité de recevoir des appels ainsi que de passer des communications locales et vers les
+Numéros gratuits et d’urgence. Le débit du service d’accès à internet maintenu peut être restreint
+Par l’opérateur, sous réserve de préserver un accès fonctionnel aux services de communication au
+Public en ligne et aux services de courrier électronique. » ;
 
-3° (nouveau) À l’avant-dernier alinéa, après le mot : « gaz », sont insérés les mots : « d’un service de téléphonie fixe ou d’un service d’accès à internet ».
+3° (nouveau) À l’avant-dernier alinéa, après le mot : « gaz », sont insérés les mots : « d’un
+Service de téléphonie fixe ou d’un service d’accès à internet ».
 
-II. – La loi n° 90‑449 du 31 mai 1990 visant à la mise en œuvre du droit au logement est ainsi modifiée :
+II. – La loi n° 90‑449 du 31 mai 1990 visant à la mise en œuvre du droit au logement est ainsi
+Modifiée :
 
-1° À la première phrase du troisième alinéa de l’article 6, les mots : « et de téléphone » sont remplacés par les mots : « , de téléphone et d’accès à internet » ;
+1° À la première phrase du troisième alinéa de l’article 6, les mots : « et de téléphone » sont
+Remplacés par les mots : « , de téléphone et d’accès à internet » ;
 
-2° Au dernier alinéa de l’article 6‑1, les mots : « ou de services téléphoniques » sont remplacés par les mots : « , de services téléphoniques ou de services d’accès à internet ».
+2° Au dernier alinéa de l’article 6‑1, les mots : « ou de services téléphoniques » sont remplacés
+Par les mots : « , de services téléphoniques ou de services d’accès à internet ».
 
-3° (nouveau) Au deuxième alinéa de l’article 6‑3, après le mot : « eau », sont insérés les mots : « ou de services téléphoniques ou d’accès à internet ».
+3° (nouveau) Au deuxième alinéa de l’article 6‑3, après le mot : « eau », sont insérés les mots :
+« ou de services téléphoniques ou d’accès à internet ».
 
 Article 45 bis (nouveau)
 
 Le code du travail est ainsi modifié :
 
-1° Au second alinéa de l’article L. 6111‑2, après le mot : « française », sont insérés les mots : « ainsi que les actions de lutte contre l’illettrisme numérique » ;
+1° Au second alinéa de l’article L. 6111‑2, après le mot : « française », sont insérés les mots :
+« ainsi que les actions de lutte contre l’illettrisme numérique » ;
 
-2° Le troisième alinéa de l’article L. 6321‑1 est complété par les mots : « et l’illettrisme numérique ».
+2° Le troisième alinéa de l’article L. 6321‑1 est complété par les mots : « et l’illettrisme
+Numérique ».
 
 Chapitre IV
 
@@ -104,5 +178,6 @@ Accès des personnes détenues à internet
 
 Article 45 ter (nouveau)
 
-Il est remis au Parlement, avant le 1<sup>er</sup> janvier 2017, un rapport sur les conditions et les modalités de mise en œuvre de l’accès au numérique de toutes les personnes privées de liberté.
+Il est remis au Parlement, avant le 1<sup>er</sup> janvier 2017, un rapport sur les conditions et
+Les modalités de mise en œuvre de l’accès au numérique de toutes les personnes privées de liberté.
 

--- a/Titre III/Chapitre Ier - Numérique et territoires.md
+++ b/Titre III/Chapitre Ier - Numérique et territoires.md
@@ -2,15 +2,15 @@ TITRE III
 
 L’accÈs au numérique
 
-Chapitre I<sup>er</sup>
+## Chapitre I<sup>er</sup>
 
 Numérique et territoires
 
-Section 1
+### Section 1
 
 Compétences et organisation
 
-Article 35
+#### Article 35
 
 Le chapitre V du titre II du livre IV de la première partie du code général des collectivités
 Territoriales est complété par un article L. 1425‑3 ainsi rédigé :
@@ -29,7 +29,7 @@ Social et environnemental régional, des conseils de développement concernés e
 Directeur territorial d’aménagement numérique à un pôle métropolitain. Dans ce cas, les opérateurs
 Ont l’obligation d’une couverture équilibrée entre les territoires urbains, périurbains et ruraux. »
 
-Article 36
+#### Article 36
 
 Après le deuxième alinéa du I de l’article L. 1425‑1 du code général des collectivités
 Territoriales, sont insérés deux alinéas ainsi rédigés :
@@ -44,16 +44,16 @@ Mixte n’est possible que si ce dernier comprend au moins une région ou un dé
 Des compétences mentionnées au premier alinéa du présent I ne peut plus être membre d’un syndicat
 Mixte relevant du titre II du livre VII. »
 
-Article 36 bis (nouveau)
+#### Article 36 bis (nouveau)
 
 Le second alinéa de l’article L. 33‑11 du code des postes et des communications électroniques est
 Complété par les mots : « avant le 31 décembre 2016 ».
 
-Section 2
+### Section 2
 
 Couverture numérique
 
-Article 37 A (nouveau)
+#### Article 37 A (nouveau)
 
 L’article L. 1615‑7 du code général des collectivités territoriales est complété par un alinéa
 Ainsi rédigé :
@@ -64,7 +64,7 @@ Réalisées sur la période 2015‑2022, sous maîtrise d’ouvrage publique, en
 Passives intégrant leur patrimoine dans le cadre du plan d’action relatif à l’extension de la
 Couverture du territoire par les réseaux de téléphonie mobile. »
 
-Article 37 B (nouveau)
+#### Article 37 B (nouveau)
 
 L’article L. 48 du code des postes et des communications électroniques est ainsi modifié :
 
@@ -88,9 +88,9 @@ A) Les mots : « qu’elle résulte du partage d’une installation déjà autor
 Servitude et » sont supprimés ;
 
 B) La référence : « à l’article L. 45‑9 » est remplacée par la référence : « au c du présent
-Article ».
+#### Article ».
 
-Article 37 C (nouveau)
+#### Article 37 C (nouveau)
 
 L’article 24‑2 de la loi n° 65‑557 du 10 juillet 1965 fixant le statut de la copropriété des
 Immeubles bâtis est complété par deux alinéas ainsi rédigés :
@@ -110,7 +110,7 @@ Des postes et des communications électroniques, fait l’objet d’une conventi
 Conditions prévues à l’article L. 33‑6 du même code avec le syndicat des copropriétaires, après avis
 Du conseil syndical lorsque celui-ci a été institué. »
 
-Article 37 D (nouveau)
+#### Article 37 D (nouveau)
 
 La seconde phrase du 7° du I de l’article 39 decies du code général des impôts est remplacée par
 Trois phrases ainsi rédigées :
@@ -124,7 +124,7 @@ Par dérogation au même premier alinéa, la déduction s’applique aux droits 
 Mentionnés au présent 7° qui sont acquis ou fabriqués par l’entreprise à compter du 1<sup>er</sup>
 Janvier 2016 et jusqu’au 31 décembre 2016. »
 
-Article 37 E (nouveau)
+#### Article 37 E (nouveau)
 
 Après le troisième alinéa de l’article L. 34‑8‑3 du code des postes et des communications
 électroniques, il est inséré un alinéa ainsi rédigé :
@@ -134,7 +134,7 @@ Zone de déploiement, elle peut réserver l’application de cette péréquation
 Ne déploient pas de lignes à très haut débit en fibre optique permettant de desservir des logements
 Situés dans cette zone. »
 
-Article 37 F (nouveau)
+#### Article 37 F (nouveau)
 
 Le septième alinéa du III de l’article L. 36‑11 du code des postes et des communications
 électroniques est ainsi rédigé :
@@ -147,7 +147,7 @@ Fréquences qui lui a été attribuée. Sont notamment considérées comme non c
 Présent alinéa, les zones rurales dans lesquelles l’entretien et la maintenance des matériels,
 Logiciels et installations constituant le réseau ne sont pas normalement assurés ; ».
 
-Article 37
+#### Article 37
 
 L’article L. 36‑7 du code des postes et des communications électroniques est complété par un 11°
 Ainsi rédigé :
@@ -159,7 +159,7 @@ Application du présent code et des décisions prises pour son application, ains
 Servant à les établir dont elle fixe la liste et que les fournisseurs lui transmettent
 Préalablement. »
 
-Article 37 bis (nouveau)
+#### Article 37 bis (nouveau)
 
 Le II de l’article 52‑1 de la loi n° 2004‑575 du 21 juin 2004 pour la confiance dans l’économie
 Numérique est complété par une phrase ainsi rédigée :
@@ -169,7 +169,7 @@ Alinéa du III de l’article 52 peut demander à figurer sur une liste complém
 Mêmes conditions dans un délai de six mois à compter de la promulgation de la loi n° du pour une
 République numérique. »
 
-Article 38
+#### Article 38
 
 Le chapitre V du titre II du livre I<sup>er</sup> de la deuxième partie du code général de la
 Propriété des personnes publiques est complété par une section 4 ainsi rédigée :
@@ -191,7 +191,7 @@ Utilisateur ne donne pas lieu au paiement d’une redevance.
 « L’utilisation des fréquences radioélectriques autorisées à des fins exclusivement expérimentales
 Peut ne pas donner lieu au paiement d’une redevance. »
 
-Article 39
+#### Article 39
 
 Le livre II du code des postes et des communications électroniques est ainsi modifié :
 
@@ -211,7 +211,7 @@ Deuxième ou troisième alinéas de l’article L. 35‑2 remet au ministre char
 Rapport présentant un état des lieux détaillé de son réseau fixe. Ce rapport comporte une analyse, à
 L’échelle du département, de l’état du réseau lorsque ne sont pas remplies les obligations,
 Notamment de qualité, prévues par le cahier des charges mentionné à l’avant‑dernier alinéa du même
-Article L. 35‑2.
+#### Article L. 35‑2.
 
 « Sauf si leur divulgation est susceptible de porter atteinte au secret des affaires, au secret
 Commercial ou au secret statistique, l’Autorité de régulation des communications électroniques et

--- a/Titre III/Chapitre Ier - Numérique et territoires.md
+++ b/Titre III/Chapitre Ier - Numérique et territoires.md
@@ -12,163 +12,297 @@ Compétences et organisation
 
 Article 35
 
-Le chapitre V du titre II du livre IV de la première partie du code général des collectivités territoriales est complété par un article L. 1425‑3 ainsi rédigé :
+Le chapitre V du titre II du livre IV de la première partie du code général des collectivités
+Territoriales est complété par un article L. 1425‑3 ainsi rédigé :
 
-« Art. L. 1425‑3. – Dans les domaines de compétence que la loi leur attribue, les conseils départementaux ou régionaux ou les syndicats mixtes mentionnés à l’article L. 5721‑9 dont le périmètre recouvre l’intégralité du territoire couvert par le schéma peuvent établir une stratégie de développement des usages et services numériques sur leur territoire. Cette stratégie constitue un volet du schéma directeur territorial d’aménagement numérique. Elle vise à favoriser l’équilibre de l’offre de services numériques sur le territoire ainsi que la mise en place de ressources mutualisées, publiques et privées, notamment en matière de médiation numérique. Le projet de stratégie fait l’objet d’une concertation pour recueillir les observations du conseil économique, social et environnemental régional, des conseils de développement concernés et du public.
+« Art. L. 1425‑3. – Dans les domaines de compétence que la loi leur attribue, les conseils
+Départementaux ou régionaux ou les syndicats mixtes mentionnés à l’article L. 5721‑9 dont le
+Périmètre recouvre l’intégralité du territoire couvert par le schéma peuvent établir une stratégie
+De développement des usages et services numériques sur leur territoire. Cette stratégie constitue un
+Volet du schéma directeur territorial d’aménagement numérique. Elle vise à favoriser l’équilibre de
+L’offre de services numériques sur le territoire ainsi que la mise en place de ressources
+Mutualisées, publiques et privées, notamment en matière de médiation numérique. Le projet de
+Stratégie fait l’objet d’une concertation pour recueillir les observations du conseil économique,
+Social et environnemental régional, des conseils de développement concernés et du public.
 
-« Les conseils départementaux ou les conseils régionaux peuvent déléguer la mise en œuvre du schéma directeur territorial d’aménagement numérique à un pôle métropolitain. Dans ce cas, les opérateurs ont l’obligation d’une couverture équilibrée entre les territoires urbains, périurbains et ruraux. »
+« Les conseils départementaux ou les conseils régionaux peuvent déléguer la mise en œuvre du schéma
+Directeur territorial d’aménagement numérique à un pôle métropolitain. Dans ce cas, les opérateurs
+Ont l’obligation d’une couverture équilibrée entre les territoires urbains, périurbains et ruraux. »
 
 Article 36
 
-Après le deuxième alinéa du I de l’article L. 1425‑1 du code général des collectivités territoriales, sont insérés deux alinéas ainsi rédigés :
+Après le deuxième alinéa du I de l’article L. 1425‑1 du code général des collectivités
+Territoriales, sont insérés deux alinéas ainsi rédigés :
 
-« Par dérogation au premier alinéa de l’article L. 5721‑2, un syndicat mixte relevant du titre II du livre VII peut adhérer à un autre syndicat mixte exerçant, par transfert ou délégation, tout ou partie des compétences mentionnées au premier alinéa du présent I, jusqu’au 31 décembre 2019.
+« Par dérogation au premier alinéa de l’article L. 5721‑2, un syndicat mixte relevant du titre II
+Du livre VII peut adhérer à un autre syndicat mixte exerçant, par transfert ou délégation, tout ou
+Partie des compétences mentionnées au premier alinéa du présent I, jusqu’au 31 décembre 2019.
 
-« L’adhésion d’un syndicat mixte qui exerce ses compétences par délégation à un autre syndicat mixte n’est possible que si ce dernier comprend au moins une région ou un département. À compter du 1<sup>er</sup> janvier 2022, un syndicat mixte exerçant, par transfert ou délégation, tout ou partie des compétences mentionnées au premier alinéa du présent I ne peut plus être membre d’un syndicat mixte relevant du titre II du livre VII. »
+« L’adhésion d’un syndicat mixte qui exerce ses compétences par délégation à un autre syndicat
+Mixte n’est possible que si ce dernier comprend au moins une région ou un département. À compter du
+1<sup>er</sup> janvier 2022, un syndicat mixte exerçant, par transfert ou délégation, tout ou partie
+Des compétences mentionnées au premier alinéa du présent I ne peut plus être membre d’un syndicat
+Mixte relevant du titre II du livre VII. »
 
 Article 36 bis (nouveau)
 
-Le second alinéa de l’article L. 33‑11 du code des postes et des communications électroniques est complété par les mots : « avant le 31 décembre 2016 ».
+Le second alinéa de l’article L. 33‑11 du code des postes et des communications électroniques est
+Complété par les mots : « avant le 31 décembre 2016 ».
 
 Section 2
 
 Couverture numérique
 
-Article 37 A (nouveau)
+Article 37 A (nouveau)
 
-L’article L. 1615‑7 du code général des collectivités territoriales est complété par un alinéa ainsi rédigé :
+L’article L. 1615‑7 du code général des collectivités territoriales est complété par un alinéa
+Ainsi rédigé :
 
-« Les collectivités territoriales et leurs groupements bénéficient des attributions du Fonds de compensation pour la taxe sur la valeur ajoutée au titre de leurs dépenses d’investissement réalisées sur la période 2015‑2022, sous maîtrise d’ouvrage publique, en matière d’infrastructures passives intégrant leur patrimoine dans le cadre du plan d’action relatif à l’extension de la couverture du territoire par les réseaux de téléphonie mobile. »
+« Les collectivités territoriales et leurs groupements bénéficient des attributions du Fonds de
+Compensation pour la taxe sur la valeur ajoutée au titre de leurs dépenses d’investissement
+Réalisées sur la période 2015‑2022, sous maîtrise d’ouvrage publique, en matière d’infrastructures
+Passives intégrant leur patrimoine dans le cadre du plan d’action relatif à l’extension de la
+Couverture du territoire par les réseaux de téléphonie mobile. »
 
-Article 37 B (nouveau)
+Article 37 B (nouveau)
 
-L’article L. 48 du code des postes et des communications électroniques est ainsi modifié :
+L’article L. 48 du code des postes et des communications électroniques est ainsi modifié :
 
-1° Au a, après le mot : « Sur », sont insérés les mots : « les bâtiments d’habitation et sur » ;
+1° Au a, après le mot : « Sur », sont insérés les mots : « les bâtiments d’habitation et sur » ;
 
-2° Le c est ainsi modifié :
+2° Le c est ainsi modifié :
 
-a) Les mots : « Au-dessus » sont remplacés par les mots : « Sur et au-dessus » ;
+A) Les mots : « Au-dessus » sont remplacés par les mots : « Sur et au-dessus » ;
 
-b) Après le mot : « privées », sont insérés les mots : « , y compris à l’extérieur des murs ou façades donnant sur la voie publique, » ;
+B) Après le mot : « privées », sont insérés les mots : « , y compris à l’extérieur des murs ou
+Façades donnant sur la voie publique, » ;
 
-c) Est ajoutée une phrase ainsi rédigée : 
+C) Est ajoutée une phrase ainsi rédigée :
 
-« En cas de contrainte technique, l’installation est déployée à proximité de celle bénéficiant de la servitude en suivant au mieux le cheminement de cette dernière. » ;
+« En cas de contrainte technique, l’installation est déployée à proximité de celle bénéficiant de
+La servitude en suivant au mieux le cheminement de cette dernière. » ;
 
-3° L’avant-dernière phrase du sixième alinéa est ainsi modifiée :
+3° L’avant-dernière phrase du sixième alinéa est ainsi modifiée :
 
-a) Les mots : « qu’elle résulte du partage d’une installation déjà autorisée au titre d’une autre servitude et » sont supprimés ;
+A) Les mots : « qu’elle résulte du partage d’une installation déjà autorisée au titre d’une autre
+Servitude et » sont supprimés ;
 
-b) La référence : « à l’article L. 45‑9 » est remplacée par la référence : « au c du présent article ».
+B) La référence : « à l’article L. 45‑9 » est remplacée par la référence : « au c du présent
+Article ».
 
-Article 37 C (nouveau)
+Article 37 C (nouveau)
 
-L’article 24‑2 de la loi n° 65‑557 du 10 juillet 1965 fixant le statut de la copropriété des immeubles bâtis est complété par deux alinéas ainsi rédigés :
+L’article 24‑2 de la loi n° 65‑557 du 10 juillet 1965 fixant le statut de la copropriété des
+Immeubles bâtis est complété par deux alinéas ainsi rédigés :
 
-« Lorsqu’une demande de raccordement à un réseau de communications électroniques à très haut débit en fibre optique est effectuée par l’occupant d’un logement d’un immeuble comportant plusieurs logements ou d’un immeuble à usage mixte dans les conditions prévues à l’article 1<sup>er</sup> de la loi n° 66‑457 du 2 juillet 1966 relative à l’installation d’antennes réceptrices de radiodiffusion, le syndicat des copropriétaires ne peut s’opposer, nonobstant toute convention contraire, sans motif sérieux et légitime conformément au II du même article 1<sup>er</sup>, à l’installation de telles lignes dans les parties communes de l’immeuble de manière à permettre la desserte de chacun des logements, sous réserve que l’immeuble dispose des infrastructures d’accueil adaptées.
+« Lorsqu’une demande de raccordement à un réseau de communications électroniques à très haut débit
+En fibre optique est effectuée par l’occupant d’un logement d’un immeuble comportant plusieurs
+Logements ou d’un immeuble à usage mixte dans les conditions prévues à l’article 1<sup>er</sup> de
+La loi n° 66‑457 du 2 juillet 1966 relative à l’installation d’antennes réceptrices de
+Radiodiffusion, le syndicat des copropriétaires ne peut s’opposer, nonobstant toute convention
+Contraire, sans motif sérieux et légitime conformément au II du même article 1<sup>er</sup>, à
+L’installation de telles lignes dans les parties communes de l’immeuble de manière à permettre la
+Desserte de chacun des logements, sous réserve que l’immeuble dispose des infrastructures d’accueil
+Adaptées.
 
-« Cette installation, réalisée aux frais de l’opérateur conformément à l’article L. 34‑8‑3 du code des postes et des communications électroniques, fait l’objet d’une convention conclue dans les conditions prévues à l’article L. 33‑6 du même code avec le syndicat des copropriétaires, après avis du conseil syndical lorsque celui-ci a été institué. »
+« Cette installation, réalisée aux frais de l’opérateur conformément à l’article L. 34‑8‑3 du code
+Des postes et des communications électroniques, fait l’objet d’une convention conclue dans les
+Conditions prévues à l’article L. 33‑6 du même code avec le syndicat des copropriétaires, après avis
+Du conseil syndical lorsque celui-ci a été institué. »
 
 Article 37 D (nouveau)
 
-La seconde phrase du 7° du I de l’article 39 decies du code général des impôts est remplacée par trois phrases ainsi rédigées :
+La seconde phrase du 7° du I de l’article 39 decies du code général des impôts est remplacée par
+Trois phrases ainsi rédigées :
 
-« En cas de cession de droits d’usage portant sur les biens mentionnés à la première phrase du présent 7°, le montant des investissements éligibles est égal à la différence entre le montant total des investissements effectués et le montant des droits d’usage cédés à une entreprise tierce. Par dérogation au premier alinéa du présent I, les entreprises titulaires d’un droit d’usage portant sur ces biens peuvent déduire une somme égale à 40 % du montant facturé au titre de ce droit d’usage. Par dérogation au même premier alinéa, la déduction s’applique aux droits d’usage et aux biens mentionnés au présent 7° qui sont acquis ou fabriqués par l’entreprise à compter du 1<sup>er</sup> janvier 2016 et jusqu’au 31 décembre 2016. »
+« En cas de cession de droits d’usage portant sur les biens mentionnés à la première phrase du
+Présent 7°, le montant des investissements éligibles est égal à la différence entre le montant total
+Des investissements effectués et le montant des droits d’usage cédés à une entreprise tierce. Par
+Dérogation au premier alinéa du présent I, les entreprises titulaires d’un droit d’usage portant sur
+Ces biens peuvent déduire une somme égale à 40 % du montant facturé au titre de ce droit d’usage.
+Par dérogation au même premier alinéa, la déduction s’applique aux droits d’usage et aux biens
+Mentionnés au présent 7° qui sont acquis ou fabriqués par l’entreprise à compter du 1<sup>er</sup>
+Janvier 2016 et jusqu’au 31 décembre 2016. »
 
 Article 37 E (nouveau)
 
-Après le troisième alinéa de l’article L. 34‑8‑3 du code des postes et des communications électroniques, il est inséré un alinéa ainsi rédigé :
+Après le troisième alinéa de l’article L. 34‑8‑3 du code des postes et des communications
+électroniques, il est inséré un alinéa ainsi rédigé :
 
-« Lorsque la personne qui fournit l’accès met en œuvre une péréquation tarifaire à l’échelle de la zone de déploiement, elle peut réserver l’application de cette péréquation aux seuls opérateurs qui ne déploient pas de lignes à très haut débit en fibre optique permettant de desservir des logements situés dans cette zone. »
+« Lorsque la personne qui fournit l’accès met en œuvre une péréquation tarifaire à l’échelle de la
+Zone de déploiement, elle peut réserver l’application de cette péréquation aux seuls opérateurs qui
+Ne déploient pas de lignes à très haut débit en fibre optique permettant de desservir des logements
+Situés dans cette zone. »
 
 Article 37 F (nouveau)
 
-Le septième alinéa du III de l’article L. 36‑11 du code des postes et des communications électroniques est ainsi rédigé :
+Le septième alinéa du III de l’article L. 36‑11 du code des postes et des communications
+électroniques est ainsi rédigé :
 
-« – une sanction pécuniaire dont le montant est proportionné à la gravité du manquement, appréciée notamment au regard du nombre d’habitants ou de kilomètres carrés non couverts ou de sites non couverts, lorsque la personne en cause ne s’est pas conformée à une mise en demeure portant sur le respect d’obligations de couverture de la population prévues par l’autorisation d’utilisation de fréquences qui lui a été attribuée. Sont notamment considérées comme non couvertes, au sens du présent alinéa, les zones rurales dans lesquelles l’entretien et la maintenance des matériels, logiciels et installations constituant le réseau ne sont pas normalement assurés ; ».
+« – une sanction pécuniaire dont le montant est proportionné à la gravité du manquement, appréciée
+Notamment au regard du nombre d’habitants ou de kilomètres carrés non couverts ou de sites non
+Couverts, lorsque la personne en cause ne s’est pas conformée à une mise en demeure portant sur le
+Respect d’obligations de couverture de la population prévues par l’autorisation d’utilisation de
+Fréquences qui lui a été attribuée. Sont notamment considérées comme non couvertes, au sens du
+Présent alinéa, les zones rurales dans lesquelles l’entretien et la maintenance des matériels,
+Logiciels et installations constituant le réseau ne sont pas normalement assurés ; ».
 
 Article 37
 
-L’article L. 36‑7 du code des postes et des communications électroniques est complété par un 11° ainsi rédigé :
+L’article L. 36‑7 du code des postes et des communications électroniques est complété par un 11°
+Ainsi rédigé :
 
-« 11° Met à disposition du public, sous forme électronique, dans un standard ouvert aisément réutilisable, sous réserve de mentionner leurs sources, les cartes numériques de couverture du territoire que les fournisseurs de services de communications électroniques sont tenus de publier en application du présent code et des décisions prises pour son application, ainsi que les données servant à les établir dont elle fixe la liste et que les fournisseurs lui transmettent préalablement. »
+« 11° Met à disposition du public, sous forme électronique, dans un standard ouvert aisément
+Réutilisable, sous réserve de mentionner leurs sources, les cartes numériques de couverture du
+Territoire que les fournisseurs de services de communications électroniques sont tenus de publier en
+Application du présent code et des décisions prises pour son application, ainsi que les données
+Servant à les établir dont elle fixe la liste et que les fournisseurs lui transmettent
+Préalablement. »
 
-Article 37 bis (nouveau)
+Article 37 bis (nouveau)
 
-Le II de l’article 52‑1 de la loi n° 2004‑575 du 21 juin 2004 pour la confiance dans l’économie numérique est complété par une phrase ainsi rédigée :
+Le II de l’article 52‑1 de la loi n° 2004‑575 du 21 juin 2004 pour la confiance dans l’économie
+Numérique est complété par une phrase ainsi rédigée :
 
-« Toute commune ne figurant pas sur la liste précitée et répondant aux critères fixés au premier alinéa du III de l’article 52 peut demander à figurer sur une liste complémentaire, établie dans les mêmes conditions dans un délai de six mois à compter de la promulgation de la loi n°     du       pour une République numérique. »
+« Toute commune ne figurant pas sur la liste précitée et répondant aux critères fixés au premier
+Alinéa du III de l’article 52 peut demander à figurer sur une liste complémentaire, établie dans les
+Mêmes conditions dans un délai de six mois à compter de la promulgation de la loi n° du pour une
+République numérique. »
 
 Article 38
 
-Le chapitre V du titre II du livre I<sup>er</sup> de la deuxième partie du code général de la propriété des personnes publiques est complété par une section 4 ainsi rédigée :
+Le chapitre V du titre II du livre I<sup>er</sup> de la deuxième partie du code général de la
+Propriété des personnes publiques est complété par une section 4 ainsi rédigée :
 
-« Section 4
+« Section 4
 
-« Dispositions particulières aux services de communications électroniques utilisant le domaine public hertzien
+« Dispositions particulières aux services de communications électroniques utilisant le domaine
+Public hertzien
 
-« Art. L. 2125‑10. – La redevance due par un opérateur de communications électroniques pour l’occupation ou l’utilisation du domaine public des fréquences radioélectriques tient compte, d’une part, des avantages de toute nature procurés au titulaire de l’autorisation eu égard à l’utilisation à laquelle ces fréquences sont destinées et, d’autre part, de l’objectif d’utilisation et de gestion efficaces des fréquences radioélectriques.
+« Art. L. 2125‑10. – La redevance due par un opérateur de communications électroniques pour
+L’occupation ou l’utilisation du domaine public des fréquences radioélectriques tient compte, d’une
+Part, des avantages de toute nature procurés au titulaire de l’autorisation eu égard à l’utilisation
+à laquelle ces fréquences sont destinées et, d’autre part, de l’objectif d’utilisation et de gestion
+Efficaces des fréquences radioélectriques.
 
-« L’utilisation de fréquences radioélectriques qui n’ont pas été spécifiquement assignées à un utilisateur ne donne pas lieu au paiement d’une redevance.
+« L’utilisation de fréquences radioélectriques qui n’ont pas été spécifiquement assignées à un
+Utilisateur ne donne pas lieu au paiement d’une redevance.
 
-« L’utilisation des fréquences radioélectriques autorisées à des fins exclusivement expérimentales peut ne pas donner lieu au paiement d’une redevance. »
+« L’utilisation des fréquences radioélectriques autorisées à des fins exclusivement expérimentales
+Peut ne pas donner lieu au paiement d’une redevance. »
 
 Article 39
 
-Le livre II du code des postes et des communications électroniques est ainsi modifié :
+Le livre II du code des postes et des communications électroniques est ainsi modifié :
 
-A. – L’article L. 35 complété par un alinéa ainsi rédigé :
+A. – L’article L. 35 complété par un alinéa ainsi rédigé :
 
-« En vue de garantir la permanence, la qualité et la disponibilité des réseaux et du service, l’entretien des réseaux assurant des services fixes de communications électroniques ouverts au public et de leurs abords est d’utilité publique. » ;
+« En vue de garantir la permanence, la qualité et la disponibilité des réseaux et du service,
+L’entretien des réseaux assurant des services fixes de communications électroniques ouverts au
+Public et de leurs abords est d’utilité publique. » ;
 
-B. – Le chapitre III du titre I<sup>er</sup> est complété par un article L. 35‑7 ainsi rétabli :
+B. – Le chapitre III du titre I<sup>er</sup> est complété par un article L. 35‑7 ainsi rétabli :
 
-« Art. L. 35‑7. – Au plus tard trois mois avant l’expiration de la période pour laquelle elle a été chargée, en application de l’article L. 35‑2, de fournir la composante du service universel prévue au 1° de l’article L. 35‑1, toute personne désignée dans le cadre de la procédure prévue aux deuxième ou troisième alinéas de l’article L. 35‑2 remet au ministre chargé des communications électroniques ainsi qu’à l’Autorité de régulation des communications électroniques et des postes un rapport présentant un état des lieux détaillé de son réseau fixe. Ce rapport comporte une analyse, à l’échelle du département, de l’état du réseau lorsque ne sont pas remplies les obligations, notamment de qualité, prévues par le cahier des charges mentionné à l’avant‑dernier alinéa du même article L. 35‑2.
+« Art. L. 35‑7. – Au plus tard trois mois avant l’expiration de la période pour laquelle elle a été
+Chargée, en application de l’article L. 35‑2, de fournir la composante du service universel prévue
+Au 1° de l’article L. 35‑1, toute personne désignée dans le cadre de la procédure prévue aux
+Deuxième ou troisième alinéas de l’article L. 35‑2 remet au ministre chargé des communications
+électroniques ainsi qu’à l’Autorité de régulation des communications électroniques et des postes un
+Rapport présentant un état des lieux détaillé de son réseau fixe. Ce rapport comporte une analyse, à
+L’échelle du département, de l’état du réseau lorsque ne sont pas remplies les obligations,
+Notamment de qualité, prévues par le cahier des charges mentionné à l’avant‑dernier alinéa du même
+Article L. 35‑2.
 
-« Sauf si leur divulgation est susceptible de porter atteinte au secret des affaires, au secret commercial ou au secret statistique, l’Autorité de régulation des communications électroniques et des postes communique aux collectivités territoriales et à leurs groupements concernés, à leur demande, tout ou partie de ce rapport. » ;
+« Sauf si leur divulgation est susceptible de porter atteinte au secret des affaires, au secret
+Commercial ou au secret statistique, l’Autorité de régulation des communications électroniques et
+Des postes communique aux collectivités territoriales et à leurs groupements concernés, à leur
+Demande, tout ou partie de ce rapport. » ;
 
-C. – L’article L. 36‑11 est ainsi modifié :
+C. – L’article L. 36‑11 est ainsi modifié :
 
-1° À la première phrase du premier alinéa, après la deuxième occurrence du mot : « électroniques, », sont insérés les mots : « d’une collectivité territoriale ou d’un groupement de collectivités territoriales, » ;
+1° À la première phrase du premier alinéa, après la deuxième occurrence du mot : « électroniques,
+», sont insérés les mots : « d’une collectivité territoriale ou d’un groupement de collectivités
+Territoriales, » ;
 
-2° Après le sixième alinéa du III, il est inséré un alinéa ainsi rédigé :
+2° Après le sixième alinéa du III, il est inséré un alinéa ainsi rédigé :
 
-« – lorsqu’une personne chargée, en application de l’article L. 35‑2, de fournir des prestations de service universel ne s’est pas conformée à une mise en demeure portant sur le respect d’obligations pesant sur elle à ce titre, une sanction pécuniaire dont le montant est proportionné à la gravité du manquement et aux avantages qui en sont tirés, sans pouvoir excéder 5 % du chiffre d’affaires hors taxes du dernier exercice clos, taux porté à 10 % en cas de nouvelle violation de la même obligation. À défaut d’activité permettant de déterminer ce plafond, le montant de la sanction ne peut excéder 150 000 €, porté à 375 000 € en cas de nouvelle violation de la même obligation ; »
+« – lorsqu’une personne chargée, en application de l’article L. 35‑2, de fournir des prestations de
+Service universel ne s’est pas conformée à une mise en demeure portant sur le respect d’obligations
+Pesant sur elle à ce titre, une sanction pécuniaire dont le montant est proportionné à la gravité du
+Manquement et aux avantages qui en sont tirés, sans pouvoir excéder 5 % du chiffre d’affaires hors
+Taxes du dernier exercice clos, taux porté à 10 % en cas de nouvelle violation de la même
+Obligation. À défaut d’activité permettant de déterminer ce plafond, le montant de la sanction ne
+Peut excéder 150 000 €, porté à 375 000 € en cas de nouvelle violation de la même obligation ; »
 
-D. – L’article L. 47 est ainsi modifié :
+D. – L’article L. 47 est ainsi modifié :
 
-1° Au deuxième alinéa, après le mot : « réseaux », sont insérés les mots : « et de leurs abords, » ;
+1° Au deuxième alinéa, après le mot : « réseaux », sont insérés les mots : « et de leurs abords, »
+;
 
-2° À la deuxième phrase du cinquième alinéa, après le mot : « équipements », sont insérés les mots : « , y compris de leurs abords, » ;
+2° À la deuxième phrase du cinquième alinéa, après le mot : « équipements », sont insérés les mots
+: « , y compris de leurs abords, » ;
 
-E. – L’article L. 48 est ainsi modifié :
+E. – L’article L. 48 est ainsi modifié :
 
-1° Le premier alinéa est ainsi modifié :
+1° Le premier alinéa est ainsi modifié :
 
-a) Les mots : « et l’exploitation » sont remplacés par les mots : « , l’exploitation et l’entretien » ;
+A) Les mots : « et l’exploitation » sont remplacés par les mots : « , l’exploitation et
+L’entretien » ;
 
-b) Sont ajoutés les mots : « , ainsi que pour permettre les opérations d’entretien des abords des réseaux permettant d’assurer des services fixes de communications électroniques ouverts au public, telles que le débroussaillage, la coupe d’herbe, l’élagage et l’abattage » ;
+B) Sont ajoutés les mots : « , ainsi que pour permettre les opérations d’entretien des abords des
+Réseaux permettant d’assurer des services fixes de communications électroniques ouverts au public,
+Telles que le débroussaillage, la coupe d’herbe, l’élagage et l’abattage » ;
 
-2° Le huitième alinéa est ainsi modifié :
+2° Le huitième alinéa est ainsi modifié :
 
-a) Les mots : « et l’exploitation des installations » sont remplacés par les mots : « , l’exploitation et l’entretien des installations ou pour les opérations d’entretien mentionnées au premier alinéa » ;
+A) Les mots : « et l’exploitation des installations » sont remplacés par les mots : « ,
+L’exploitation et l’entretien des installations ou pour les opérations d’entretien mentionnées au
+Premier alinéa » ;
 
-b) Le mot : « premier » est remplacé par le mot : « même » ;
+B) Le mot : « premier » est remplacé par le mot : « même » ;
 
-c) Après le mot : « amiable », sont insérés les mots : « ou de convention conclue entre le propriétaire et l’exploitant » ;
+C) Après le mot : « amiable », sont insérés les mots : « ou de convention conclue entre le
+Propriétaire et l’exploitant » ;
 
-F. – L’article L. 50 est ainsi rétabli :
+F. – L’article L. 50 est ainsi rétabli :
 
-« Art. L. 50. – I. – Les opérations d’entretien des abords d’un réseau ouvert au public permettant d’assurer des services fixes de communications électroniques, telles que le débroussaillage, la coupe d’herbe, l’élagage et l’abattage, sont accomplies par le propriétaire du terrain, le fermier ou leurs représentants, que la propriété soit riveraine ou non du domaine public, afin de prévenir l’endommagement des équipements du réseau et l’interruption du service. À cette fin, l’exploitant du réseau ouvert au public est tenu de proposer au propriétaire du terrain, au fermier ou à leurs représentants l’établissement d’une convention. Sur le domaine public, les modalités de réalisation des coupes sont définies par la convention prévue au premier alinéa de l’article L. 46 ou par la permission de voirie prévue au troisième alinéa de l’article L. 47.
+« Art. L. 50. – I. – Les opérations d’entretien des abords d’un réseau ouvert au public permettant
+D’assurer des services fixes de communications électroniques, telles que le débroussaillage, la
+Coupe d’herbe, l’élagage et l’abattage, sont accomplies par le propriétaire du terrain, le fermier
+Ou leurs représentants, que la propriété soit riveraine ou non du domaine public, afin de prévenir
+L’endommagement des équipements du réseau et l’interruption du service. À cette fin, l’exploitant du
+Réseau ouvert au public est tenu de proposer au propriétaire du terrain, au fermier ou à leurs
+Représentants l’établissement d’une convention. Sur le domaine public, les modalités de réalisation
+Des coupes sont définies par la convention prévue au premier alinéa de l’article L. 46 ou par la
+Permission de voirie prévue au troisième alinéa de l’article L. 47.
 
-« Par dérogation au premier alinéa du présent I, ces opérations sont accomplies par l’exploitant du réseau ouvert au public assurant des services fixes de communications électroniques :
+« Par dérogation au premier alinéa du présent I, ces opérations sont accomplies par l’exploitant du
+Réseau ouvert au public assurant des services fixes de communications électroniques :
 
-« 1° Lorsque le propriétaire du terrain, le fermier ou leurs représentants ne sont pas identifiés ;
+« 1° Lorsque le propriétaire du terrain, le fermier ou leurs représentants ne sont pas identifiés ;
 
-« 2° Lorsque l’exploitant et le propriétaire du terrain, le fermier ou leurs représentants en ont convenu ainsi par convention, notamment lorsque les coûts exposés par ces opérations sont particulièrement élevés pour ces derniers ou lorsque la réalisation de ces opérations présente des difficultés techniques ou pratiques de nature à porter atteinte à la sécurité ou à l’intégrité des réseaux.
+« 2° Lorsque l’exploitant et le propriétaire du terrain, le fermier ou leurs représentants en ont
+Convenu ainsi par convention, notamment lorsque les coûts exposés par ces opérations sont
+Particulièrement élevés pour ces derniers ou lorsque la réalisation de ces opérations présente des
+Difficultés techniques ou pratiques de nature à porter atteinte à la sécurité ou à l’intégrité des
+Réseaux.
 
-« II. – En cas de défaillance de leur part, ces opérations sont accomplies par l’exploitant du réseau ouvert au public assurant des services fixes de communications électroniques, aux frais du propriétaire du terrain, du fermier ou de leurs représentants. L’exécution des travaux doit être précédée d’une notification aux intéressés, ainsi qu’au maire de la commune sur le territoire de laquelle la propriété est située. L’introduction des agents de l’exploitant en vue de procéder aux opérations d’entretien s’effectue selon les modalités prévues au huitième alinéa de l’article L. 48.
+« II. – En cas de défaillance de leur part, ces opérations sont accomplies par l’exploitant du
+Réseau ouvert au public assurant des services fixes de communications électroniques, aux frais du
+Propriétaire du terrain, du fermier ou de leurs représentants. L’exécution des travaux doit être
+Précédée d’une notification aux intéressés, ainsi qu’au maire de la commune sur le territoire de
+Laquelle la propriété est située. L’introduction des agents de l’exploitant en vue de procéder aux
+Opérations d’entretien s’effectue selon les modalités prévues au huitième alinéa de l’article L. 48.
 
-« III. – Sans préjudice des procédures prévues aux articles L. 2212‑2‑2 du code général des collectivités territoriales et L. 114‑2 du code de la voirie routière et de la procédure mise en œuvre au titre de l’article L. 161‑5 du code rural et de la pêche maritime, lorsque l’entretien des abords des équipements du réseau n’est pas assuré dans des conditions permettant de prévenir leur endommagement ou les risques d’interruption du service, le maire peut transmettre, au nom de l’État, une mise en demeure au propriétaire, en informant l’exploitant concerné de celle-ci. Si celle-ci reste infructueuse durant un délai de quinze jours, le maire peut notifier le constat de carence du propriétaire à l’exploitant aux fins qu’il procède lui-même aux travaux conformément au II du présent article. Si cette notification à l’exploitant reste elle‑même infructueuse dans le délai de quinze jours, le maire peut faire procéder lui‑même à ces opérations aux frais de l’exploitant, dans le respect des règles régissant les interventions des exploitants. »
+« III. – Sans préjudice des procédures prévues aux articles L. 2212‑2‑2 du code général des
+Collectivités territoriales et L. 114‑2 du code de la voirie routière et de la procédure mise en
+œuvre au titre de l’article L. 161‑5 du code rural et de la pêche maritime, lorsque l’entretien des
+Abords des équipements du réseau n’est pas assuré dans des conditions permettant de prévenir leur
+Endommagement ou les risques d’interruption du service, le maire peut transmettre, au nom de l’État,
+Une mise en demeure au propriétaire, en informant l’exploitant concerné de celle-ci. Si celle-ci
+Reste infructueuse durant un délai de quinze jours, le maire peut notifier le constat de carence du
+Propriétaire à l’exploitant aux fins qu’il procède lui-même aux travaux conformément au II du
+Présent article. Si cette notification à l’exploitant reste elle‑même infructueuse dans le délai de
+Quinze jours, le maire peut faire procéder lui‑même à ces opérations aux frais de l’exploitant, dans
+Le respect des règles régissant les interventions des exploitants. »
 

--- a/Titre IV/DISPOSITIONS RELATIVES A L OUTRE-MER.md
+++ b/Titre IV/DISPOSITIONS RELATIVES A L OUTRE-MER.md
@@ -4,183 +4,216 @@ DISPOSITIONS RELATIVES À L’OUTRE‑MER
 
 Article 46
 
-I. – Les articles 1<sup>er</sup> à 9, les I et III de l’article 10, les articles 11, 13 à 16, 18, 26 à 33, 41 et les I et IV de l’article 43 de la présente loi sont applicables en Nouvelle‑Calédonie.
+I. – Les articles 1<sup>er</sup> à 9, les I et III de l’article 10, les articles 11, 13 à 16, 18,
+26 à 33, 41 et les I et IV de l’article 43 de la présente loi sont applicables en
+Nouvelle‑Calédonie.
 
-II. – Les articles 1<sup>er</sup> à 5, le II de l’article 8, les articles 9 à 9 ter, les I et III de l’article 10, les articles 11, 13 à 16, 16 ter, 18, 26 à 33 quater et 41 et les I et IV de l’article 43 de la présente loi sont applicables en Polynésie française.
+II. – Les articles 1<sup>er</sup> à 5, le II de l’article 8, les articles 9 à 9 ter, les I et III
+De l’article 10, les articles 11, 13 à 16, 16 ter, 18, 26 à 33 quater et 41 et les I et IV de
+L’article 43 de la présente loi sont applicables en Polynésie française.
 
-III. – Les articles 1<sup>er</sup> à 9, les I et III de l’article 10, les articles 11 à 16 et 18, le 1° du I et le II de l’article 21, les articles 26 à 34, 41 et les I et IV de l’article 43 de la présente loi sont applicables dans les îles Wallis et Futuna.
+III. – Les articles 1<sup>er</sup> à 9, les I et III de l’article 10, les articles 11 à 16 et 18,
+Le 1° du I et le II de l’article 21, les articles 26 à 34, 41 et les I et IV de l’article 43 de la
+Présente loi sont applicables dans les îles Wallis et Futuna.
 
-IV. – Les articles 1<sup>er</sup> à 9, les I et III de l’article 10, les articles 11 à 18, 26 à 33, les I et IV de l’article 43 et le I de l’article 44 sont applicables dans les Terres australes et antarctiques françaises.
+IV. – Les articles 1<sup>er</sup> à 9, les I et III de l’article 10, les articles 11 à 18, 26 à
+33, les I et IV de l’article 43 et le I de l’article 44 sont applicables dans les Terres australes
+Et antarctiques françaises.
 
 Article 47
 
-I. – Le livre I<sup>er</sup> du code de la consommation est ainsi modifié :
+I. – Le livre I<sup>er</sup> du code de la consommation est ainsi modifié :
 
-1° L’article L. 123‑1 est complété par un alinéa ainsi rédigé :
+1° L’article L. 123‑1 est complété par un alinéa ainsi rédigé :
 
-« Les articles L. 121‑120 à L. 121‑125 sont applicables dans les îles Wallis et Futuna. » ;
+« Les articles L. 121‑120 à L. 121‑125 sont applicables dans les îles Wallis et Futuna. » ;
 
-2° Le chapitre IV du titre I<sup>er</sup> est complété par un article L. 116‑2 ainsi rédigé :
+2° Le chapitre IV du titre I<sup>er</sup> est complété par un article L. 116‑2 ainsi rédigé :
 
-« Art. L. 116‑2. – Les articles L. 111‑5, L. 111‑5‑1 à L. 111‑5‑3 et L. 111‑6‑1, dans leur rédaction résultant de la loi n°     du      pour une République numérique, sont applicables dans les îles Wallis et Futuna. »
+« Art. L. 116‑2. – Les articles L. 111‑5, L. 111‑5‑1 à L. 111‑5‑3 et L. 111‑6‑1, dans leur
+Rédaction résultant de la loi n° du pour une République numérique, sont applicables dans les îles
+Wallis et Futuna. »
 
-II. – Le titre IV du livre V du code de la recherche est ainsi modifié :
+II. – Le titre IV du livre V du code de la recherche est ainsi modifié :
 
-1° Après le premier alinéa de l’article L. 546‑1, il est inséré un alinéa ainsi rédigé :
+1° Après le premier alinéa de l’article L. 546‑1, il est inséré un alinéa ainsi rédigé :
 
-« L’article L. 533‑4, dans sa rédaction résultant de la loi n°      du       pour une République numérique, est applicable en Polynésie française, sous réserve des compétences de la collectivité en matière de droit civil et de propriété intellectuelle. » ;
+« L’article L. 533‑4, dans sa rédaction résultant de la loi n° du pour une République numérique,
+Est applicable en Polynésie française, sous réserve des compétences de la collectivité en matière de
+Droit civil et de propriété intellectuelle. » ;
 
-2° Après le premier alinéa de l’article L. 547‑1, il est inséré un alinéa ainsi rédigé :
+2° Après le premier alinéa de l’article L. 547‑1, il est inséré un alinéa ainsi rédigé :
 
-« L’article L. 533‑4, dans sa rédaction résultant de la loi n°       du       pour une République numérique, est applicable en Nouvelle‑Calédonie, sous réserve des compétences de la collectivité en matière de droit civil et de propriété intellectuelle. » ;
+« L’article L. 533‑4, dans sa rédaction résultant de la loi n° du pour une République numérique,
+Est applicable en Nouvelle‑Calédonie, sous réserve des compétences de la collectivité en matière de
+Droit civil et de propriété intellectuelle. » ;
 
-3° Après le premier alinéa de l’article L. 545‑1, il est inséré un alinéa ainsi rédigé :
+3° Après le premier alinéa de l’article L. 545‑1, il est inséré un alinéa ainsi rédigé :
 
-« L’article L. 533‑4, dans sa rédaction résultant de la loi n°        du         pour une République numérique, est applicable dans les îles Wallis et Futuna. »
+« L’article L. 533‑4, dans sa rédaction résultant de la loi n° du pour une République numérique,
+Est applicable dans les îles Wallis et Futuna. »
 
-III. – Le livre V du code des relations entre le public et l’administration est ainsi modifié :
+III. – Le livre V du code des relations entre le public et l’administration est ainsi modifié :
 
-1° Le tableau du second alinéa de l’article L. 552‑8 est ainsi modifié :
+1° Le tableau du second alinéa de l’article L. 552‑8 est ainsi modifié :
 
-a) La sixième ligne est remplacée par quatre lignes ainsi rédigées :
+A) La sixième ligne est remplacée par quatre lignes ainsi rédigées :
 
-| «   | L. 311‑1 à L. 311‑3 | Résultant de l’ordonnance n° 2015‑1341 |      |
+| « | L. 311‑1 à L. 311‑3 | Résultant de l’ordonnance n° 2015‑1341 | |
 |-----|---------------------|----------------------------------------|------|
-|     | L. 311‑3‑1          | Résultant de la loi n°   du            
-                             pour une République numérique           |      |
-|     | L. 311‑4            | Résultant de la loi n°   du            
-                             pour une République numérique           |      |
-|     | L. 311‑5 à L. 311‑9 | Résultant de l’ordonnance n° 2015‑1341 |  » ; |
+| | L. 311‑3‑1 | Résultant de la loi n° du
+ pour une République numérique | |
+| | L. 311‑4 | Résultant de la loi n° du
+ pour une République numérique | |
+| | L. 311‑5 à L. 311‑9 | Résultant de l’ordonnance n° 2015‑1341 | » ; |
 
-b) La huitième ligne est remplacée par deux lignes ainsi rédigées :
+B) La huitième ligne est remplacée par deux lignes ainsi rédigées :
 
-| «   | L. 312‑1 à L. 312‑1‑2 | Résultant de la loi n°   du            
-                               pour une République numérique           |      |
+| « | L. 312‑1 à L. 312‑1‑2 | Résultant de la loi n° du
+ pour une République numérique | |
 |-----|-----------------------|----------------------------------------|------|
-|     | L. 312‑2              | Résultant de l’ordonnance n° 2015‑1341 |  » ; |
+| | L. 312‑2 | Résultant de l’ordonnance n° 2015‑1341 | » ; |
 
-c) L’avant‑dernière ligne est ainsi rédigée :
+C) L’avant‑dernière ligne est ainsi rédigée :
 
-| «   | L. 341‑1 | Résultant de la loi n°   du    
-                  pour une République numérique   |  » ; |
+| « | L. 341‑1 | Résultant de la loi n° du
+ pour une République numérique | » ; |
 |-----|----------|--------------------------------|------|
 
-d) La dernière ligne est remplacée par deux lignes ainsi rédigées :
+D) La dernière ligne est remplacée par deux lignes ainsi rédigées :
 
-| «   | L. 342‑1 et L. 342‑2 | Résultant de la loi n°   du            
-                              pour une République numérique           |      |
+| « | L. 342‑1 et L. 342‑2 | Résultant de la loi n° du
+ pour une République numérique | |
 |-----|----------------------|----------------------------------------|------|
-|     | L. 342‑3             | Résultant de l’ordonnance n° 2015‑1341 |  » ; |
+| | L. 342‑3 | Résultant de l’ordonnance n° 2015‑1341 | » ; |
 
-2° L’article L. 552‑15 est ainsi rédigé :
+2° L’article L. 552‑15 est ainsi rédigé :
 
-« Art. L. 552‑15. – Pour l’application des articles L. 311‑8 et L. 312‑1‑2 en Polynésie française, les références aux articles L. 212‑2, L. 212‑3, L. 213‑1, L. 213‑2 et L. 213‑3 du code du patrimoine sont remplacées par la référence à la réglementation localement applicable. » ;
+« Art. L. 552‑15. – Pour l’application des articles L. 311‑8 et L. 312‑1‑2 en Polynésie française,
+Les références aux articles L. 212‑2, L. 212‑3, L. 213‑1, L. 213‑2 et L. 213‑3 du code du patrimoine
+Sont remplacées par la référence à la réglementation localement applicable. » ;
 
-3° La troisième ligne du tableau du second alinéa de l’article L. 553‑2 est remplacée par deux lignes ainsi rédigées :
+3° La troisième ligne du tableau du second alinéa de l’article L. 553‑2 est remplacée par deux
+Lignes ainsi rédigées :
 
-| «   | L. 311‑1 à L. 311‑3 | Résultant de l’ordonnance n° 2015‑1341 |      |
+| « | L. 311‑1 à L. 311‑3 | Résultant de l’ordonnance n° 2015‑1341 | |
 |-----|---------------------|----------------------------------------|------|
-|     | L. 311‑3‑1          | Résultant de la loi n°   du            
-                             pour une République numérique           |  » ; |
+| | L. 311‑3‑1 | Résultant de la loi n° du
+ pour une République numérique | » ; |
 
-4° Le tableau du second alinéa de l’article L. 562‑8 est ainsi modifié :
+4° Le tableau du second alinéa de l’article L. 562‑8 est ainsi modifié :
 
-a) La sixième ligne est remplacée par quatre lignes ainsi rédigées :
+A) La sixième ligne est remplacée par quatre lignes ainsi rédigées :
 
-| «   | L. 311‑1 à L. 311‑3 | Résultant de l’ordonnance n° 2015‑1341 |      |
+| « | L. 311‑1 à L. 311‑3 | Résultant de l’ordonnance n° 2015‑1341 | |
 |-----|---------------------|----------------------------------------|------|
-|     | L. 311‑3‑1          | Résultant de la loi n°   du            
-                             pour une République numérique           |      |
-|     | L. 311‑4            | Résultant de la loi n°   du            
-                             pour une République numérique           |      |
-|     | L. 311‑5 à L. 311‑9 | Résultant de l’ordonnance n° 2015‑1341 |  » ; |
+| | L. 311‑3‑1 | Résultant de la loi n° du
+ pour une République numérique | |
+| | L. 311‑4 | Résultant de la loi n° du
+ pour une République numérique | |
+| | L. 311‑5 à L. 311‑9 | Résultant de l’ordonnance n° 2015‑1341 | » ; |
 
-b) La huitième ligne est remplacée par deux lignes ainsi rédigées :
+B) La huitième ligne est remplacée par deux lignes ainsi rédigées :
 
-| «   | L. 312‑1 à L. 312‑1‑2 | Résultant de la loi n°   du            
-                               pour une République numérique           |      |
+| « | L. 312‑1 à L. 312‑1‑2 | Résultant de la loi n° du
+ pour une République numérique | |
 |-----|-----------------------|----------------------------------------|------|
-|     | L. 312‑2              | Résultant de l’ordonnance n° 2015‑1341 |  » ; |
+| | L. 312‑2 | Résultant de l’ordonnance n° 2015‑1341 | » ; |
 
-c) L’avant‑dernière ligne est ainsi rédigée :
+C) L’avant‑dernière ligne est ainsi rédigée :
 
-| «   | L. 341‑1 | Résultant de la loi n°   du    
-                  pour une République numérique   |  » ; |
+| « | L. 341‑1 | Résultant de la loi n° du
+ pour une République numérique | » ; |
 |-----|----------|--------------------------------|------|
 
-d) La dernière ligne est remplacée par deux lignes ainsi rédigées :
+D) La dernière ligne est remplacée par deux lignes ainsi rédigées :
 
-| «   | L. 342‑1 et L. 342‑2 | Résultant de la loi n°                 
-                              pour une République numérique           |      |
+| « | L. 342‑1 et L. 342‑2 | Résultant de la loi n°
+ pour une République numérique | |
 |-----|----------------------|----------------------------------------|------|
-|     | L. 342‑3             | Résultant de l’ordonnance n° 2015‑1341 |  » ; |
+| | L. 342‑3 | Résultant de l’ordonnance n° 2015‑1341 | » ; |
 
-5° L’article L. 562‑16 est ainsi rédigé :
+5° L’article L. 562‑16 est ainsi rédigé :
 
-« Art. L. 562‑16. – Pour l’application des articles L. 311‑8 et L. 312‑1‑2 en Nouvelle‑Calédonie, les références aux articles L. 212‑2, L. 212‑3, L. 213‑1, L. 213‑2 et L. 213‑3 du code du patrimoine sont remplacées par la référence à la réglementation localement applicable. » ;
+« Art. L. 562‑16. – Pour l’application des articles L. 311‑8 et L. 312‑1‑2 en Nouvelle‑Calédonie,
+Les références aux articles L. 212‑2, L. 212‑3, L. 213‑1, L. 213‑2 et L. 213‑3 du code du patrimoine
+Sont remplacées par la référence à la réglementation localement applicable. » ;
 
-6° La troisième ligne du tableau du second alinéa de l’article L. 563‑2 est remplacée par deux lignes ainsi rédigées :
+6° La troisième ligne du tableau du second alinéa de l’article L. 563‑2 est remplacée par deux
+Lignes ainsi rédigées :
 
-| «   | L. 311‑1 à L. 311‑3 | Résultant de l’ordonnance n° 2015‑1341 |      |
+| « | L. 311‑1 à L. 311‑3 | Résultant de l’ordonnance n° 2015‑1341 | |
 |-----|---------------------|----------------------------------------|------|
-|     | L. 311‑3‑1          | Résultant de la loi n°   du            
-                             pour une République numérique           |  » ; |
+| | L. 311‑3‑1 | Résultant de la loi n° du
+ pour une République numérique | » ; |
 
-7° Le tableau du second alinéa de l’article L. 574‑1est ainsi modifié :
+7° Le tableau du second alinéa de l’article L. 574‑1est ainsi modifié :
 
-a) La quatrième ligne est remplacée par quatre lignes ainsi rédigées :
+A) La quatrième ligne est remplacée par quatre lignes ainsi rédigées :
 
-| «   | L. 311‑1 à L. 311‑3 | Résultant de l’ordonnance n° 2015‑1341 |      |
+| « | L. 311‑1 à L. 311‑3 | Résultant de l’ordonnance n° 2015‑1341 | |
 |-----|---------------------|----------------------------------------|------|
-|     | L. 311‑3‑1          | Résultant de la loi n°   du            
-                             pour une République numérique           |      |
-|     | L. 311‑4            | Résultant de la loi n°   du            
-                             pour une République numérique           |      |
-|     | L. 311‑5 à L. 311‑9 | Résultant de l’ordonnance n° 2015‑1341 |  » ; |
+| | L. 311‑3‑1 | Résultant de la loi n° du
+ pour une République numérique | |
+| | L. 311‑4 | Résultant de la loi n° du
+ pour une République numérique | |
+| | L. 311‑5 à L. 311‑9 | Résultant de l’ordonnance n° 2015‑1341 | » ; |
 
-b) La sixième ligne est remplacée par deux lignes ainsi rédigées :
+B) La sixième ligne est remplacée par deux lignes ainsi rédigées :
 
-| «   | L. 312‑1 à L. 312‑12‑2 | Résultant de la loi n°   du            
-                                pour une République numérique           |      |
+| « | L. 312‑1 à L. 312‑12‑2 | Résultant de la loi n° du
+ pour une République numérique | |
 |-----|------------------------|----------------------------------------|------|
-|     | L. 312‑2               | Résultant de l’ordonnance n° 2015‑1341 |  » ; |
+| | L. 312‑2 | Résultant de l’ordonnance n° 2015‑1341 | » ; |
 
-c) L’avant‑dernière ligne est ainsi rédigée :
+C) L’avant‑dernière ligne est ainsi rédigée :
 
-| «   | L. 341‑1 | Résultant de la loi n°   du    
-                  pour une République numérique   |  » ; |
+| « | L. 341‑1 | Résultant de la loi n° du
+ pour une République numérique | » ; |
 |-----|----------|--------------------------------|------|
 
-d) La dernière ligne est remplacée par deux lignes ainsi rédigées :
+D) La dernière ligne est remplacée par deux lignes ainsi rédigées :
 
-| «   | L. 342‑1 et L. 342‑2 | Résultant de la loi n°   du            
-                              pour une République numérique           |      |
+| « | L. 342‑1 et L. 342‑2 | Résultant de la loi n° du
+ pour une République numérique | |
 |-----|----------------------|----------------------------------------|------|
-|     | L. 342‑3             | Résultant de l’ordonnance n° 2015‑1341 |  » ; |
+| | L. 342‑3 | Résultant de l’ordonnance n° 2015‑1341 | » ; |
 
-8° La troisième ligne du tableau du second alinéa de l’article L. 574‑5 est remplacée par deux lignes ainsi rédigées :
+8° La troisième ligne du tableau du second alinéa de l’article L. 574‑5 est remplacée par deux
+Lignes ainsi rédigées :
 
-| «   | L. 311‑1 à L. 311‑3 | Résultant de l’ordonnance n° 2015‑1341 |     |
+| « | L. 311‑1 à L. 311‑3 | Résultant de l’ordonnance n° 2015‑1341 | |
 |-----|---------------------|----------------------------------------|-----|
-|     | L. 311‑3‑1          | Résultant de la loi n°   du            
-                             pour une République numérique           |  ». |
+| | L. 311‑3‑1 | Résultant de la loi n° du
+ pour une République numérique | ». |
 
-IV. – L’article L. 32‑3 du code des postes et communications électroniques, dans sa rédaction résultant de l’article 34 de la présente loi, est complété par un IV ainsi rédigé :
+IV. – L’article L. 32‑3 du code des postes et communications électroniques, dans sa rédaction
+Résultant de l’article 34 de la présente loi, est complété par un IV ainsi rédigé :
 
-« IV. – Le présent article est applicable dans les îles Wallis et Futuna. »
+« IV. – Le présent article est applicable dans les îles Wallis et Futuna. »
 
 Article 48
 
-I. – L’article 59 de la loi n° 78‑753 du 17 juillet 1978 portant diverses mesures d’amélioration des relations entre l’administration et le public et diverses dispositions d’ordre administratif, social et fiscal est ainsi modifié :
+I. – L’article 59 de la loi n° 78‑753 du 17 juillet 1978 portant diverses mesures d’amélioration
+Des relations entre l’administration et le public et diverses dispositions d’ordre administratif,
+Social et fiscal est ainsi modifié :
 
-1° (nouveau) Au I, après le mot : « française », sont insérés les mots : « , à l’exception des articles 10 à 12, du premier alinéa de l’article 13 et des articles 14 à 19 et 25, » ;
+1° (nouveau) Au I, après le mot : « française », sont insérés les mots : « , à l’exception des
+Articles 10 à 12, du premier alinéa de l’article 13 et des articles 14 à 19 et 25, » ;
 
-2° Le III est complété par un 3° ainsi rédigé :
+2° Le III est complété par un 3° ainsi rédigé :
 
-« 3° En Nouvelle‑Calédonie et en Polynésie française, les références au code de la propriété intellectuelle sont remplacées, le cas échéant, par les références aux dispositions applicables localement. »
+« 3° En Nouvelle‑Calédonie et en Polynésie française, les références au code de la propriété
+Intellectuelle sont remplacées, le cas échéant, par les références aux dispositions applicables
+Localement. »
 
-II. – Au premier alinéa de l’article 41‑1 de la loi n° 93‑122 du 29 janvier 1993 relative à la prévention de la corruption et à la transparence de la vie économique et des procédures publiques, après la référence : « 40 », est insérée la référence : « , 40‑2 ».
+II. – Au premier alinéa de l’article 41‑1 de la loi n° 93‑122 du 29 janvier 1993 relative à la
+Prévention de la corruption et à la transparence de la vie économique et des procédures publiques,
+Après la référence : « 40 », est insérée la référence : « , 40‑2 ».
 
-III. – Le I de l’article 41 de la loi n° 2000‑321 du 12 avril 2000 relative aux droits des citoyens dans leurs relations avec les administrations est complété par un alinéa ainsi rédigé :
+III. – Le I de l’article 41 de la loi n° 2000‑321 du 12 avril 2000 relative aux droits des
+Citoyens dans leurs relations avec les administrations est complété par un alinéa ainsi rédigé :
 
-« Pour l’application en Nouvelle‑Calédonie, en Polynésie française et dans les îles Wallis et Futuna des troisième à septième et avant-dernier alinéas de l’article 10, les mots : “mentionné au premier alinéa de l’article 9‑1” sont supprimés. »
+« Pour l’application en Nouvelle‑Calédonie, en Polynésie française et dans les îles Wallis et
+Futuna des troisième à septième et avant-dernier alinéas de l’article 10, les mots : “mentionné au
+Premier alinéa de l’article 9‑1” sont supprimés. »

--- a/Titre IV/DISPOSITIONS RELATIVES A L OUTRE-MER.md
+++ b/Titre IV/DISPOSITIONS RELATIVES A L OUTRE-MER.md
@@ -2,7 +2,7 @@ TITRE IV
 
 DISPOSITIONS RELATIVES À L’OUTRE‑MER
 
-Article 46
+#### Article 46
 
 I. – Les articles 1<sup>er</sup> à 9, les I et III de l’article 10, les articles 11, 13 à 16, 18,
 26 à 33, 41 et les I et IV de l’article 43 de la présente loi sont applicables en
@@ -20,7 +20,7 @@ IV. – Les articles 1<sup>er</sup> à 9, les I et III de l’article 10, les ar
 33, les I et IV de l’article 43 et le I de l’article 44 sont applicables dans les Terres australes
 Et antarctiques françaises.
 
-Article 47
+#### Article 47
 
 I. – Le livre I<sup>er</sup> du code de la consommation est ainsi modifié :
 
@@ -192,14 +192,14 @@ Résultant de l’article 34 de la présente loi, est complété par un IV ainsi
 
 « IV. – Le présent article est applicable dans les îles Wallis et Futuna. »
 
-Article 48
+#### Article 48
 
 I. – L’article 59 de la loi n° 78‑753 du 17 juillet 1978 portant diverses mesures d’amélioration
 Des relations entre l’administration et le public et diverses dispositions d’ordre administratif,
 Social et fiscal est ainsi modifié :
 
 1° (nouveau) Au I, après le mot : « française », sont insérés les mots : « , à l’exception des
-Articles 10 à 12, du premier alinéa de l’article 13 et des articles 14 à 19 et 25, » ;
+#### Articles 10 à 12, du premier alinéa de l’article 13 et des articles 14 à 19 et 25, » ;
 
 2° Le III est complété par un 3° ainsi rédigé :
 


### PR DESCRIPTION
Je pense que la lisibilité peut être grandement améliorée en appliquant ces changements:

- Ajoute des marqueurs de titres
- Majuscules en début de phrases
- Enlève les espaces non standard qui s'accumulent
- Maximise la longueur des lignes à 100 charactères pour une meilleure lisibilité sans changer le rendu des fichiers

Cela peut être fait de manière automatique avec le script que j'ai créé: https://github.com/Dorian/bin/blob/master/scripts/prettify-markdown